### PR TITLE
Add hourly detail download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,15 @@ logger:
     custom_components.battery_manager: debug
 ```
 
+### Export Hourly Details
+Use the service `battery_manager.export_hourly_details` to save the last hourly
+simulation data to a text file. When called without parameters the file will be
+written to `<config>/battery_manager_hourly_<entry_id>.txt`.
+Provide `entry_id` if multiple integrations are configured and optional
+`file_path` to override the location.
+Set `download: true` to create the file under `<config>/www` and receive a
+persistent notification with a direct download link.
+
 ### Configuration Validation
 The system validates all configuration parameters and provides clear error messages for:
 - Invalid capacity values

--- a/custom_components/battery_manager/const.py
+++ b/custom_components/battery_manager/const.py
@@ -77,3 +77,6 @@ ATTR_GRID_EXPORT_KWH = "grid_export_kwh"
 ATTR_SIMULATION_END = "simulation_end"
 ATTR_LAST_UPDATE = "last_update"
 ATTR_DATA_VALIDITY = "data_validity"
+
+# Services
+SERVICE_EXPORT_HOURLY_DETAILS = "export_hourly_details"


### PR DESCRIPTION
## Summary
- create a service to export the  hourly details available on CLI
- allow `export_hourly_details` service to optionally create a downloadable file
- document new `download` service parameter

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491be3db6c83208ab58a20a32d3e79