### PR TITLE
Expose all options

### DIFF
--- a/custom_components/battery_manager/__init__.py
+++ b/custom_components/battery_manager/__init__.py
@@ -28,7 +28,8 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Battery Manager from a config entry."""
     try:
-        coordinator = BatteryManagerCoordinator(hass, entry.data)
+        config = {**entry.data, **entry.options}
+        coordinator = BatteryManagerCoordinator(hass, config)
 
         # Fetch initial data
         await coordinator.async_config_entry_first_refresh()

--- a/custom_components/battery_manager/config_flow.py
+++ b/custom_components/battery_manager/config_flow.py
@@ -373,7 +373,7 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
         self.config_entry = config_entry
-        self.options: Dict[str, Any] = {**config_entry.data}
+        self.options: Dict[str, Any] = {**config_entry.data, **config_entry.options}
 
     async def async_step_init(
         self, user_input: Optional[Dict[str, Any]] = None
@@ -387,7 +387,10 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
             {
                 vol.Required(
                     CONF_SOC_ENTITY,
-                    default=self.config_entry.data.get(CONF_SOC_ENTITY),
+                    default=self.config_entry.options.get(
+                        CONF_SOC_ENTITY,
+                        self.config_entry.data.get(CONF_SOC_ENTITY),
+                    ),
                 ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
                         domain="sensor",
@@ -396,19 +399,28 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
                 ),
                 vol.Required(
                     CONF_PV_FORECAST_TODAY,
-                    default=self.config_entry.data.get(CONF_PV_FORECAST_TODAY),
+                    default=self.config_entry.options.get(
+                        CONF_PV_FORECAST_TODAY,
+                        self.config_entry.data.get(CONF_PV_FORECAST_TODAY),
+                    ),
                 ): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain="sensor")
                 ),
                 vol.Required(
                     CONF_PV_FORECAST_TOMORROW,
-                    default=self.config_entry.data.get(CONF_PV_FORECAST_TOMORROW),
+                    default=self.config_entry.options.get(
+                        CONF_PV_FORECAST_TOMORROW,
+                        self.config_entry.data.get(CONF_PV_FORECAST_TOMORROW),
+                    ),
                 ): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain="sensor")
                 ),
                 vol.Required(
                     CONF_PV_FORECAST_DAY_AFTER,
-                    default=self.config_entry.data.get(CONF_PV_FORECAST_DAY_AFTER),
+                    default=self.config_entry.options.get(
+                        CONF_PV_FORECAST_DAY_AFTER,
+                        self.config_entry.data.get(CONF_PV_FORECAST_DAY_AFTER),
+                    ),
                 ): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain="sensor")
                 ),
@@ -421,7 +433,11 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> FlowResult:
         """Update battery parameters."""
-        current_config = {**DEFAULT_CONFIG, **self.config_entry.data}
+        current_config = {
+            **DEFAULT_CONFIG,
+            **self.config_entry.data,
+            **self.config_entry.options,
+        }
 
         if user_input is not None:
             self.options.update(user_input)
@@ -458,7 +474,11 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> FlowResult:
         """Update PV system parameters."""
-        current_config = {**DEFAULT_CONFIG, **self.config_entry.data}
+        current_config = {
+            **DEFAULT_CONFIG,
+            **self.config_entry.data,
+            **self.config_entry.options,
+        }
 
         if user_input is not None:
             self.options.update(user_input)
@@ -495,7 +515,11 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> FlowResult:
         """Update consumer load parameters."""
-        current_config = {**DEFAULT_CONFIG, **self.config_entry.data}
+        current_config = {
+            **DEFAULT_CONFIG,
+            **self.config_entry.data,
+            **self.config_entry.options,
+        }
 
         if user_input is not None:
             self.options.update(user_input)
@@ -544,7 +568,11 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> FlowResult:
         """Update charger and inverter parameters."""
-        current_config = {**DEFAULT_CONFIG, **self.config_entry.data}
+        current_config = {
+            **DEFAULT_CONFIG,
+            **self.config_entry.data,
+            **self.config_entry.options,
+        }
 
         if user_input is not None:
             self.options.update(user_input)
@@ -589,7 +617,11 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> FlowResult:
         """Update controller parameters."""
-        current_config = {**DEFAULT_CONFIG, **self.config_entry.data}
+        current_config = {
+            **DEFAULT_CONFIG,
+            **self.config_entry.data,
+            **self.config_entry.options,
+        }
 
         if user_input is not None:
             self.options.update(user_input)

--- a/custom_components/battery_manager/config_flow.py
+++ b/custom_components/battery_manager/config_flow.py
@@ -372,7 +372,6 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
         self.options: Dict[str, Any] = {**config_entry.data, **config_entry.options}
 
     async def async_step_init(

--- a/custom_components/battery_manager/config_flow.py
+++ b/custom_components/battery_manager/config_flow.py
@@ -381,23 +381,142 @@ class BatteryManagerOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        # Create options schema with current values
         current_config = {**DEFAULT_CONFIG, **self.config_entry.data}
 
         options_schema = vol.Schema(
             {
                 vol.Required(
-                    "controller_target_soc_percent",
-                    default=current_config.get("controller_target_soc_percent", 85.0),
-                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=100)),
+                    CONF_SOC_ENTITY,
+                    default=self.config_entry.data.get(CONF_SOC_ENTITY),
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain="sensor",
+                        device_class="battery",
+                    )
+                ),
+                vol.Required(
+                    CONF_PV_FORECAST_TODAY,
+                    default=self.config_entry.data.get(CONF_PV_FORECAST_TODAY),
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor")
+                ),
+                vol.Required(
+                    CONF_PV_FORECAST_TOMORROW,
+                    default=self.config_entry.data.get(CONF_PV_FORECAST_TOMORROW),
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor")
+                ),
+                vol.Required(
+                    CONF_PV_FORECAST_DAY_AFTER,
+                    default=self.config_entry.data.get(CONF_PV_FORECAST_DAY_AFTER),
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor")
+                ),
                 vol.Required(
                     "battery_capacity_wh",
-                    default=current_config.get("battery_capacity_wh", 5000.0),
+                    default=current_config.get("battery_capacity_wh"),
                 ): vol.All(vol.Coerce(float), vol.Range(min=100, max=1000000)),
+                vol.Required(
+                    "battery_min_soc_percent",
+                    default=current_config.get("battery_min_soc_percent"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=100)),
+                vol.Required(
+                    "battery_max_soc_percent",
+                    default=current_config.get("battery_max_soc_percent"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=100)),
+                vol.Required(
+                    "battery_charge_efficiency",
+                    default=current_config.get("battery_charge_efficiency"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=1.0)),
+                vol.Required(
+                    "battery_discharge_efficiency",
+                    default=current_config.get("battery_discharge_efficiency"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=1.0)),
+                vol.Required(
+                    "pv_max_power_w",
+                    default=current_config.get("pv_max_power_w"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=100000)),
+                vol.Required(
+                    "pv_morning_start_hour",
+                    default=current_config.get("pv_morning_start_hour"),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+                vol.Required(
+                    "pv_morning_end_hour",
+                    default=current_config.get("pv_morning_end_hour"),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+                vol.Required(
+                    "pv_afternoon_end_hour",
+                    default=current_config.get("pv_afternoon_end_hour"),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+                vol.Required(
+                    "pv_morning_ratio",
+                    default=current_config.get("pv_morning_ratio"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1.0)),
+                vol.Required(
+                    "ac_base_load_w",
+                    default=current_config.get("ac_base_load_w"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=10000)),
+                vol.Required(
+                    "ac_variable_load_w",
+                    default=current_config.get("ac_variable_load_w"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=10000)),
+                vol.Required(
+                    "ac_variable_start_hour",
+                    default=current_config.get("ac_variable_start_hour"),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+                vol.Required(
+                    "ac_variable_end_hour",
+                    default=current_config.get("ac_variable_end_hour"),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+                vol.Required(
+                    "dc_base_load_w",
+                    default=current_config.get("dc_base_load_w"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=10000)),
+                vol.Required(
+                    "dc_variable_load_w",
+                    default=current_config.get("dc_variable_load_w"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=10000)),
+                vol.Required(
+                    "dc_variable_start_hour",
+                    default=current_config.get("dc_variable_start_hour"),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+                vol.Required(
+                    "dc_variable_end_hour",
+                    default=current_config.get("dc_variable_end_hour"),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+                vol.Required(
+                    "charger_max_power_w",
+                    default=current_config.get("charger_max_power_w"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=100, max=50000)),
+                vol.Required(
+                    "charger_efficiency",
+                    default=current_config.get("charger_efficiency"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=1.0)),
+                vol.Required(
+                    "charger_standby_power_w",
+                    default=current_config.get("charger_standby_power_w"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1000)),
+                vol.Required(
+                    "inverter_max_power_w",
+                    default=current_config.get("inverter_max_power_w"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=100, max=50000)),
+                vol.Required(
+                    "inverter_efficiency",
+                    default=current_config.get("inverter_efficiency"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0.1, max=1.0)),
+                vol.Required(
+                    "inverter_standby_power_w",
+                    default=current_config.get("inverter_standby_power_w"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1000)),
+                vol.Required(
+                    "inverter_min_soc_percent",
+                    default=current_config.get("inverter_min_soc_percent"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=100)),
+                vol.Required(
+                    "controller_target_soc_percent",
+                    default=current_config.get("controller_target_soc_percent"),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0, max=100)),
             }
         )
 
-        return self.async_show_form(
-            step_id="init",
-            data_schema=options_schema,
-        )
+        return self.async_show_form(step_id="init", data_schema=options_schema)

--- a/custom_components/battery_manager/coordinator.py
+++ b/custom_components/battery_manager/coordinator.py
@@ -459,16 +459,23 @@ class BatteryManagerCoordinator(DataUpdateCoordinator):
 
         # Update entity IDs if they changed
         entity_ids_changed = False
-        if CONF_SOC_ENTITY in new_config and new_config[CONF_SOC_ENTITY] != old_config.get(CONF_SOC_ENTITY):
+
+        # Check SOC entity
+        soc_entity_changed = CONF_SOC_ENTITY in new_config and new_config[
+            CONF_SOC_ENTITY
+        ] != old_config.get(CONF_SOC_ENTITY)
+        if soc_entity_changed:
             self.soc_entity_id = new_config[CONF_SOC_ENTITY]
             entity_ids_changed = True
-        
+
         for conf_key, attr_name in [
             (CONF_PV_FORECAST_TODAY, 0),
             (CONF_PV_FORECAST_TOMORROW, 1),
             (CONF_PV_FORECAST_DAY_AFTER, 2),
         ]:
-            if conf_key in new_config and new_config[conf_key] != old_config.get(conf_key):
+            if conf_key in new_config and new_config[conf_key] != old_config.get(
+                conf_key
+            ):
                 self.pv_forecast_entities[attr_name] = new_config[conf_key]
                 entity_ids_changed = True
 

--- a/custom_components/battery_manager/translations/en.json
+++ b/custom_components/battery_manager/translations/en.json
@@ -94,17 +94,35 @@
           "soc_entity": "Battery SOC Entity",
           "pv_forecast_today_entity": "PV Forecast Today Entity",
           "pv_forecast_tomorrow_entity": "PV Forecast Tomorrow Entity",
-          "pv_forecast_day_after_entity": "PV Forecast Day After Entity",
+          "pv_forecast_day_after_entity": "PV Forecast Day After Entity"
+        }
+      },
+      "battery_config": {
+        "title": "Battery Configuration",
+        "description": "Update battery parameters",
+        "data": {
           "battery_capacity_wh": "Battery Capacity (Wh)",
           "battery_min_soc_percent": "Minimum SOC (%)",
           "battery_max_soc_percent": "Maximum SOC (%)",
           "battery_charge_efficiency": "Charge Efficiency",
-          "battery_discharge_efficiency": "Discharge Efficiency",
+          "battery_discharge_efficiency": "Discharge Efficiency"
+        }
+      },
+      "pv_config": {
+        "title": "PV System Configuration",
+        "description": "Update PV system parameters",
+        "data": {
           "pv_max_power_w": "Max PV Power (W)",
           "pv_morning_start_hour": "Morning Start Hour",
           "pv_morning_end_hour": "Morning End Hour",
           "pv_afternoon_end_hour": "Afternoon End Hour",
-          "pv_morning_ratio": "Morning Production Ratio",
+          "pv_morning_ratio": "Morning Production Ratio"
+        }
+      },
+      "consumer_config": {
+        "title": "Consumer Configuration",
+        "description": "Update AC and DC load parameters",
+        "data": {
           "ac_base_load_w": "AC Base Load (W)",
           "ac_variable_load_w": "AC Variable Load (W)",
           "ac_variable_start_hour": "AC Variable Start Hour",
@@ -112,14 +130,26 @@
           "dc_base_load_w": "DC Base Load (W)",
           "dc_variable_load_w": "DC Variable Load (W)",
           "dc_variable_start_hour": "DC Variable Start Hour",
-          "dc_variable_end_hour": "DC Variable End Hour",
+          "dc_variable_end_hour": "DC Variable End Hour"
+        }
+      },
+      "power_config": {
+        "title": "Power Equipment Configuration",
+        "description": "Update charger and inverter parameters",
+        "data": {
           "charger_max_power_w": "Charger Max Power (W)",
           "charger_efficiency": "Charger Efficiency",
           "charger_standby_power_w": "Charger Standby Power (W)",
           "inverter_max_power_w": "Inverter Max Power (W)",
           "inverter_efficiency": "Inverter Efficiency",
           "inverter_standby_power_w": "Inverter Standby Power (W)",
-          "inverter_min_soc_percent": "Inverter Min SOC (%)",
+          "inverter_min_soc_percent": "Inverter Min SOC (%)"
+        }
+      },
+      "controller_config": {
+        "title": "Controller Configuration",
+        "description": "Update controller parameters",
+        "data": {
           "controller_target_soc_percent": "Target SOC Threshold (%)"
         }
       }

--- a/custom_components/battery_manager/translations/en.json
+++ b/custom_components/battery_manager/translations/en.json
@@ -91,8 +91,36 @@
         "title": "Battery Manager Options",
         "description": "Update Battery Manager configuration",
         "data": {
-          "controller_target_soc_percent": "Target SOC Threshold (%)",
-          "battery_capacity_wh": "Battery Capacity (Wh)"
+          "soc_entity": "Battery SOC Entity",
+          "pv_forecast_today_entity": "PV Forecast Today Entity",
+          "pv_forecast_tomorrow_entity": "PV Forecast Tomorrow Entity",
+          "pv_forecast_day_after_entity": "PV Forecast Day After Entity",
+          "battery_capacity_wh": "Battery Capacity (Wh)",
+          "battery_min_soc_percent": "Minimum SOC (%)",
+          "battery_max_soc_percent": "Maximum SOC (%)",
+          "battery_charge_efficiency": "Charge Efficiency",
+          "battery_discharge_efficiency": "Discharge Efficiency",
+          "pv_max_power_w": "Max PV Power (W)",
+          "pv_morning_start_hour": "Morning Start Hour",
+          "pv_morning_end_hour": "Morning End Hour",
+          "pv_afternoon_end_hour": "Afternoon End Hour",
+          "pv_morning_ratio": "Morning Production Ratio",
+          "ac_base_load_w": "AC Base Load (W)",
+          "ac_variable_load_w": "AC Variable Load (W)",
+          "ac_variable_start_hour": "AC Variable Start Hour",
+          "ac_variable_end_hour": "AC Variable End Hour",
+          "dc_base_load_w": "DC Base Load (W)",
+          "dc_variable_load_w": "DC Variable Load (W)",
+          "dc_variable_start_hour": "DC Variable Start Hour",
+          "dc_variable_end_hour": "DC Variable End Hour",
+          "charger_max_power_w": "Charger Max Power (W)",
+          "charger_efficiency": "Charger Efficiency",
+          "charger_standby_power_w": "Charger Standby Power (W)",
+          "inverter_max_power_w": "Inverter Max Power (W)",
+          "inverter_efficiency": "Inverter Efficiency",
+          "inverter_standby_power_w": "Inverter Standby Power (W)",
+          "inverter_min_soc_percent": "Inverter Min SOC (%)",
+          "controller_target_soc_percent": "Target SOC Threshold (%)"
         }
       }
     }


### PR DESCRIPTION
## Summary
- expose all setup fields in options flow
- provide UI labels for each option

## Testing
- `isort custom_components`
- `black custom_components`
- `flake8 custom_components --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 custom_components --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics`


------
https://chatgpt.com/codex/tasks/task_e_684ac65f8e5483208c3a0edca5f19357