### PR TITLE
Release v0.12.0: per-load dwell, latched power warning, built-in push notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-12
+
+### Added
+- **Per-load power-warning dwell + off by default (operator wish).** The 30-min
+  dwell before a load's power-deviation warning fires is now a per-load setting
+  ("power warning dwell", default **15 min**), so the delay is tunable per
+  device. The warning itself now defaults to **off** for new loads (deviation %
+  default `50 → 0`); the operator opts each device in. Existing loads keep their
+  stored percentage, so a load that was already warning stays on — and now also
+  gets the shorter default dwell.
+- **Built-in push notifications for power warnings (operator wish).** A new
+  *Power-warning notifications* section in the integration Options lets you pick
+  a global list of `notify` targets (e.g. each person's companion app). When any
+  load's power warning trips a push is sent to every target, and — unless the
+  "Also notify when resolved" toggle is off — another when it clears. No targets
+  configured = no push; the `binary_sensor` stays available for custom
+  automations regardless.
+
+### Changed
+- **The power warning now latches (operator report).** Once on, it stays on
+  until the load runs at its configured power again *at the integration's
+  request* — it no longer self-clears the moment BM stops requesting the load (a
+  full water tank is still full while the load is off). The latch is persisted,
+  so saving the integration options (which reloads the coordinator) or a restart
+  no longer silently drops a raised warning.
+
 ## [0.11.2] - 2026-07-12
 
 ### Fixed

--- a/custom_components/battery_manager/config_flow.py
+++ b/custom_components/battery_manager/config_flow.py
@@ -57,6 +57,7 @@ from .const import (
     CONF_LOAD_NAME,
     CONF_LOAD_POWER_ENTITY,
     CONF_LOAD_POWER_W,
+    CONF_LOAD_POWER_WARNING_DWELL_MIN,
     CONF_LOAD_POWER_WARNING_PCT,
     CONF_LOAD_PRIORITY,
     CONF_LOAD_SOC_ENTITY,
@@ -90,6 +91,8 @@ from .const import (
     CONF_SUPPORT_DC48_SWITCH,
     CONF_SUPPORT_SWITCH_DELAY_S,
     CONF_UPPER_PV_RESERVE,
+    CONF_WARNING_NOTIFY_ON_RESOLVE,
+    CONF_WARNING_NOTIFY_TARGETS,
     CONF_WORKDAY_ENTITY,
     DEFAULT_APPLIANCE_CONFIG,
     DEFAULT_CONFIG,
@@ -111,12 +114,14 @@ SECTION_PROFILE = "consumption_profile"
 SECTION_LEARNING = "consumption_learning"
 SECTION_SUPPORT = "support_paths"
 SECTION_DEVICES = "dc_devices"
+SECTION_NOTIFY = "notifications"
 _OPTION_SECTIONS = (
     SECTION_TUNING,
     SECTION_PROFILE,
     SECTION_LEARNING,
     SECTION_SUPPORT,
     SECTION_DEVICES,
+    SECTION_NOTIFY,
 )
 
 
@@ -154,6 +159,34 @@ def _entity(domain: str | list[str] | None = None, multiple: bool = False):
     if domain:
         config["domain"] = domain
     return selector.EntitySelector(config)
+
+
+def _notify_services(hass) -> list[str]:
+    """Registered `notify` service names, minus the ones that are not push
+    targets: `send_message` needs an entity_id (would raise) and the
+    persistent_notification dispatcher is not a phone."""
+    try:
+        services = hass.services.async_services_for_domain("notify")
+    except AttributeError:  # pre-2024.7 fallback
+        services = hass.services.async_services().get("notify", {})
+    return sorted(
+        name
+        for name in services
+        if name not in ("send_message", "persistent_notification")
+    )
+
+
+def _notify_targets(options: list[str]):
+    """Multi-select of notify service names. custom_value keeps a stored
+    target that isn't registered right now (e.g. a phone offline at setup)."""
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=options,
+            multiple=True,
+            custom_value=True,
+            mode=selector.SelectSelectorMode.DROPDOWN,
+        )
+    )
 
 
 def _d(config: dict[str, Any], key: str) -> Any:
@@ -774,7 +807,7 @@ class BatteryManagerOptionsFlow(OptionsFlow):
                     CONF_WORKDAY_ENTITY,
                 ):
                     data.setdefault(key, None)
-                for key in _LEARNING_MULTI_KEYS:
+                for key in (*_LEARNING_MULTI_KEYS, CONF_WARNING_NOTIFY_TARGETS):
                     data.setdefault(key, [])
                 return self.async_create_entry(title="", data=data)
             errors["base"] = error
@@ -873,6 +906,21 @@ class BatteryManagerOptionsFlow(OptionsFlow):
             )
         ] = _number(5, 30, 0.5, "%")
 
+        # Push notifications for load power warnings (operator wish 2026-07-12):
+        # a single global list of notify targets + a resolve-ping toggle.
+        notify = {
+            vol.Optional(
+                CONF_WARNING_NOTIFY_TARGETS,
+                description={
+                    "suggested_value": current.get(CONF_WARNING_NOTIFY_TARGETS)
+                },
+            ): _notify_targets(_notify_services(self.hass)),
+            vol.Required(
+                CONF_WARNING_NOTIFY_ON_RESOLVE,
+                default=_d(current, CONF_WARNING_NOTIFY_ON_RESOLVE),
+            ): selector.BooleanSelector(),
+        }
+
         # Grouped into collapsible sections for readability (F-N UX request).
         schema = {
             vol.Required(SECTION_TUNING): section(
@@ -889,6 +937,9 @@ class BatteryManagerOptionsFlow(OptionsFlow):
             ),
             vol.Required(SECTION_DEVICES): section(
                 vol.Schema(_device_param_fields(current)), {"collapsed": True}
+            ),
+            vol.Required(SECTION_NOTIFY): section(
+                vol.Schema(notify), {"collapsed": True}
             ),
         }
         return self.async_show_form(
@@ -972,6 +1023,10 @@ class SurplusLoadSubentryFlow(ConfigSubentryFlow):
             vol.Required(
                 CONF_LOAD_POWER_WARNING_PCT, default=dv(CONF_LOAD_POWER_WARNING_PCT)
             ): _number(0, 200, 5, "%"),
+            vol.Required(
+                CONF_LOAD_POWER_WARNING_DWELL_MIN,
+                default=dv(CONF_LOAD_POWER_WARNING_DWELL_MIN),
+            ): _number(0, 240, 5, "min"),
         }
         for key, domain in (
             (CONF_LOAD_POWER_ENTITY, "sensor"),

--- a/custom_components/battery_manager/const.py
+++ b/custom_components/battery_manager/const.py
@@ -184,11 +184,13 @@ STALE_LOAD_SOC_MIN = 12
 # Power-deviation warning (operator requirement F-L7, 2026-07-05): while a
 # load runs at the integration's request but its real draw deviates from the
 # configured power by more than this percentage (per-load setting, 0 =
-# disabled) for POWER_WARNING_DWELL_MIN sustained minutes, a per-load
-# warning binary sensor turns on (full water tank, wrong nominal power,
-# foreign consumer). Short defrost pauses stay below the dwell.
+# disabled, the default) for the per-load dwell in sustained minutes, a
+# per-load warning binary sensor turns on (full water tank, wrong nominal
+# power, foreign consumer). Short defrost pauses stay below the dwell. The
+# warning latches once on and clears only when the load runs at its configured
+# power again (coordinator._update_power_warnings).
 CONF_LOAD_POWER_WARNING_PCT = "power_warning_percent"
-POWER_WARNING_DWELL_MIN = 30
+CONF_LOAD_POWER_WARNING_DWELL_MIN = "power_warning_dwell_min"
 
 # End-of-charge policies for the load's input plug (docs/LOAD_CONTROL.md §3)
 INPUT_OFF_POLICY_AUTO = "auto"
@@ -199,6 +201,13 @@ INPUT_OFF_POLICIES = [
     INPUT_OFF_POLICY_ALWAYS,
     INPUT_OFF_POLICY_KEEP,
 ]
+
+# Power-warning push notifications (operator wish 2026-07-12): a single global
+# list of `notify` service names (e.g. "mobile_app_pixel") the coordinator
+# pushes to when ANY load's power warning trips (and, unless silenced, when it
+# clears). Empty list = no push. Stored in the integration options.
+CONF_WARNING_NOTIFY_TARGETS = "power_warning_notify_targets"
+CONF_WARNING_NOTIFY_ON_RESOLVE = "power_warning_notify_on_resolve"
 
 # Persistent state (SOC cache, plug ownership) survives HA restarts
 STORAGE_VERSION = 1
@@ -332,6 +341,9 @@ DEFAULT_CONFIG = {
     CONF_PSU48_ON_VOLTAGE_V: 49.56,
     CONF_PSU48_OFF_VOLTAGE_V: 49.8,
     CONF_PSU48_CTRL_LOG_ONLY: True,  # arm only after a shakedown
+    # Power-warning push notifications (operator wish 2026-07-12)
+    CONF_WARNING_NOTIFY_TARGETS: [],
+    CONF_WARNING_NOTIFY_ON_RESOLVE: True,
 }
 
 # A load counts as "really running" for the runtime counter when its measured
@@ -354,7 +366,10 @@ DEFAULT_LOAD_CONFIG = {
     CONF_LOAD_TARGET_SOC: 100.0,
     CONF_LOAD_INPUT_OFF_POLICY: INPUT_OFF_POLICY_AUTO,
     CONF_LOAD_IN_HOUSE: True,
-    CONF_LOAD_POWER_WARNING_PCT: 50.0,
+    # Off by default (0 %); the operator opts a load in per device. Existing
+    # loads keep their stored value, so a load already warning stays on.
+    CONF_LOAD_POWER_WARNING_PCT: 0.0,
+    CONF_LOAD_POWER_WARNING_DWELL_MIN: 15,
 }
 
 DEFAULT_APPLIANCE_CONFIG = {

--- a/custom_components/battery_manager/coordinator.py
+++ b/custom_components/battery_manager/coordinator.py
@@ -50,6 +50,7 @@ from .const import (
     CONF_LOAD_MIN_RUNTIME_MIN,
     CONF_LOAD_POWER_ENTITY,
     CONF_LOAD_POWER_W,
+    CONF_LOAD_POWER_WARNING_DWELL_MIN,
     CONF_LOAD_POWER_WARNING_PCT,
     CONF_LOAD_PRIORITY,
     CONF_LOAD_SOC_ENTITY,
@@ -81,6 +82,8 @@ from .const import (
     CONF_SUPPORT_DC48_SWITCH,
     CONF_SUPPORT_SWITCH_DELAY_S,
     CONF_UPPER_PV_RESERVE,
+    CONF_WARNING_NOTIFY_ON_RESOLVE,
+    CONF_WARNING_NOTIFY_TARGETS,
     DC48_CTRL_DWELL_OFF_S,
     DC48_CTRL_DWELL_ON_S,
     DC48_CTRL_FAILSAFE_MIN,
@@ -100,7 +103,6 @@ from .const import (
     LOAD_SOC_CACHE_MAX_AGE_HOURS,
     MAX_HISTORICAL_FORECAST_AGE_HOURS,
     MAX_HISTORICAL_SOC_AGE_HOURS,
-    POWER_WARNING_DWELL_MIN,
     PREDRAIN_PV_CONFIDENCE_DEFAULT,
     PV_FORECAST_MODE_AUTO,
     PV_FORECAST_MODE_DAILY,
@@ -424,6 +426,14 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 for k, v in data.get("load_learned_power", {}).items()
                 if k in self.entry.subentries
             }
+            # F-L7 latched power warning: restore per-load, dropping entries
+            # whose subentry vanished (a re-created load must not inherit a
+            # stale warning). The dwell timer is intentionally NOT restored.
+            self._load_power_warning = {
+                k: bool(v)
+                for k, v in data.get("load_power_warning", {}).items()
+                if k in self.entry.subentries
+            }
             # The tick cursor (_load_run_since) is intentionally not restored —
             # see _persistent_payload; the first tick re-arms it so a restart gap
             # is never credited as runtime.
@@ -498,6 +508,12 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "support_manual": dict(self._support_manual),
             "support_state": dict(self._support_state),
             "dc48_ctrl_caused_off": self._dc48_ctrl_caused_off,
+            # F-L7: the latched power warning survives reloads/restarts so an
+            # options save (which reloads the coordinator) does not silently
+            # drop a raised warning. Only the bool is persisted; the dwell
+            # timer re-arms after a restart (a not-yet-tripped deviation is
+            # deliberately not credited across downtime).
+            "load_power_warning": dict(self._load_power_warning),
         }
 
     def _save_persistent_state(self) -> None:
@@ -1003,23 +1019,30 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             result.import_trade_used_wh,
         )
 
-    def _update_power_warnings(self, result, now: datetime) -> None:
+    async def _update_power_warnings(self, result, now: datetime) -> None:
         """Per-load power-deviation warning (operator requirement F-L7).
 
         While a load runs at the integration's request but its real draw
         deviates from the CONFIGURED power by more than the per-load
-        percentage for POWER_WARNING_DWELL_MIN sustained minutes, the
-        load's warning binary sensor turns on — full water tank (draw near
-        0 W), wrong nominal power or a foreign consumer on the measured
-        outlet. Short defrost pauses reset the timer before the dwell
-        elapses. A missing reading freezes the current state.
+        percentage for the per-load dwell in sustained minutes, the load's
+        warning binary sensor turns on — full water tank (draw near 0 W),
+        wrong nominal power or a foreign consumer on the measured outlet.
+        Short defrost pauses reset the timer before the dwell elapses. A
+        missing reading freezes the current state.
+
+        The warning LATCHES: once on, it clears only when the load runs at
+        its configured power again (active + measured back within band), not
+        merely because BM stopped requesting it — a full tank is still full
+        while the load is off (operator wish 2026-07-12). On the on/off edge
+        it pushes a notification to the configured targets.
         """
         active_by_id = {lp.load_id: lp.active_now for lp in result.load_plans}
         for subentry_id, subentry in self.entry.subentries.items():
             if subentry.subentry_type != SUBENTRY_TYPE_LOAD:
                 continue
             data = subentry.data
-            # Subentries created before v0.6.3 lack the key: default 50 %.
+            # Subentries created before the warning existed lack the key:
+            # default 0 % (off) — the operator opts a load in per device.
             pct = float(
                 data.get(
                     CONF_LOAD_POWER_WARNING_PCT,
@@ -1028,14 +1051,27 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             power_entity = data.get(CONF_LOAD_POWER_ENTITY)
             if pct <= 0 or not power_entity:
-                continue  # disabled or nothing to measure
+                # Warning disabled (0 %) or no feedback sensor: drop any
+                # lingering latch/timer so the feature turns fully off (and a
+                # latch can never get stuck once recovery is unobservable).
+                self._load_deviation_since.pop(subentry_id, None)
+                if self._load_power_warning.pop(subentry_id, None):
+                    self._save_persistent_state()
+                continue
+            dwell = float(
+                data.get(
+                    CONF_LOAD_POWER_WARNING_DWELL_MIN,
+                    DEFAULT_LOAD_CONFIG[CONF_LOAD_POWER_WARNING_DWELL_MIN],
+                )
+            )
             if subentry_id in self._load_charging_active:
                 active = self._load_charging_active[subentry_id]
             else:
                 active = active_by_id.get(subentry_id, False)
             if not active:
+                # Reset the dwell timer, but keep a latched warning on: it
+                # clears only when the load demonstrably runs again.
                 self._load_deviation_since.pop(subentry_id, None)
-                self._set_power_warning(subentry_id, subentry.title, False)
                 continue
             raw = self._read_float(power_entity)
             if raw is None:
@@ -1047,39 +1083,98 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "since": self._load_deviation_since.get(subentry_id),
             }
             if abs(raw - nominal) <= pct / 100.0 * nominal:
+                # Demonstrably running at its configured power again -> clear.
                 self._load_deviation_since.pop(subentry_id, None)
-                self._set_power_warning(subentry_id, subentry.title, False)
+                await self._set_power_warning(subentry_id, subentry.title, False)
                 continue
             since = self._load_deviation_since.setdefault(subentry_id, now)
             self._load_warning_diag[subentry_id]["since"] = since
-            if now - since >= timedelta(minutes=POWER_WARNING_DWELL_MIN):
-                self._set_power_warning(
-                    subentry_id, subentry.title, True, raw=raw, nominal=nominal
+            if now - since >= timedelta(minutes=dwell):
+                await self._set_power_warning(
+                    subentry_id,
+                    subentry.title,
+                    True,
+                    raw=raw,
+                    nominal=nominal,
+                    dwell=dwell,
                 )
 
-    def _set_power_warning(
+    async def _set_power_warning(
         self,
         subentry_id: str,
         title: str,
         on: bool,
         raw: float | None = None,
         nominal: float | None = None,
+        dwell: float | None = None,
     ) -> None:
         if self._load_power_warning.get(subentry_id, False) == on:
             return
         self._load_power_warning[subentry_id] = on
+        # Persist the latch so a coordinator reload (any options save) or a
+        # restart does not silently drop a raised warning (operator wish
+        # 2026-07-12); async_flush_persistent_state writes it before a reload.
+        self._save_persistent_state()
         if on:
             _LOGGER.warning(
                 "Load %s draws %.0f W while %.0f W are configured"
-                " (sustained > %d min) — full tank, wrong configured power"
+                " (sustained > %g min) — full tank, wrong configured power"
                 " or a foreign consumer?",
                 title,
                 raw,
                 nominal,
-                POWER_WARNING_DWELL_MIN,
+                dwell,
+            )
+            await self._notify_power_warning(
+                title, on=True, raw=raw, nominal=nominal, dwell=dwell
             )
         else:
             _LOGGER.info("Load %s: power warning cleared", title)
+            await self._notify_power_warning(title, on=False)
+
+    async def _notify_power_warning(
+        self,
+        title: str,
+        on: bool,
+        raw: float | None = None,
+        nominal: float | None = None,
+        dwell: float | None = None,
+    ) -> None:
+        """Push the power warning to the configured global notify targets.
+
+        Targets are `notify` service names (e.g. "mobile_app_pixel"); each is
+        called independently so one stale/removed target (ServiceNotFound)
+        neither stalls the update nor blocks the others. No targets -> no-op.
+        """
+        targets = self.raw_config.get(CONF_WARNING_NOTIFY_TARGETS) or []
+        if not targets:
+            return
+        if on:
+            msg_title = f"⚠️ {title}: power warning"
+            message = (
+                f"{title} draws {raw:.0f} W but {nominal:.0f} W are configured"
+                f" (sustained over {dwell:g} min). Check the device — full"
+                " water tank, wrong configured power, or a foreign consumer."
+            )
+        else:
+            if not self.raw_config.get(CONF_WARNING_NOTIFY_ON_RESOLVE, True):
+                return
+            msg_title = f"✅ {title}: power warning cleared"
+            message = f"{title} draws its configured power again."
+        for service in targets:
+            try:
+                await self.hass.services.async_call(
+                    "notify",
+                    service,
+                    {"title": msg_title, "message": message},
+                    blocking=False,
+                )
+            except Exception as err:
+                _LOGGER.warning(
+                    "Power-warning notification to notify.%s failed: %s",
+                    service,
+                    err,
+                )
 
     def _update_plan_active(self, result) -> None:
         """Track each load's plan activation and its learning permission.
@@ -1736,7 +1831,7 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._apply_load_switching(
             result, now, tuple(s.duration for s in inputs.slots)
         )
-        self._update_power_warnings(result, now)
+        await self._update_power_warnings(result, now)
         self._update_gate_calibration(config, soc)
 
         self._successful_updates += 1

--- a/custom_components/battery_manager/manifest.json
+++ b/custom_components/battery_manager/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danielr0815/battery-manager-ha/issues",
   "requirements": [],
-  "version": "0.11.2"
+  "version": "0.12.0"
 }

--- a/custom_components/battery_manager/translations/de.json
+++ b/custom_components/battery_manager/translations/de.json
@@ -290,7 +290,8 @@
             "in_house_measurement": "In Hauslast-Messung enthalten",
             "power_warning_percent": "Leistungsabweichungs-Warnung (%)",
             "control_switch_entity": "Steuerschalter / Steckdose (optional — BM schaltet direkt)",
-            "input_off_policy": "Steckdose beim Abschalten"
+            "input_off_policy": "Steckdose beim Abschalten",
+            "power_warning_dwell_min": "Verzögerung Leistungswarnung (Min.)"
           },
           "data_description": {
             "name": "Anzeigename der Last — erscheint im Untereintrag und im Namen der Empfehlungs-Entität.",
@@ -303,9 +304,10 @@
             "power_entity": "Sensor mit der real gemessenen Aufnahmeleistung. Ersetzt (geglättet) die Nennleistung in der Planung, sobald Messwerte vorliegen.",
             "availability_entity": "Die Last wird nur eingeplant, wenn diese Entität an/verfügbar ist — z. B. ein input_boolean als manueller Freigabeschalter. Bei off/unavailable/unknown wird die Last ignoriert.",
             "in_house_measurement": "Eingeschaltet lassen, wenn diese Last hinter dem konfigurierten Verbrauchs-Messpunkt hängt — sie wird dann beim Lernen der Grundlast herausgerechnet. Ausschalten, wenn die Last außerhalb versorgt wird (z. B. über einen Einspeise-Sollwert): Sonst würde sie doppelt abgezogen.",
-            "power_warning_percent": "Warnschwelle für die Abweichung zwischen realer Leistung und Nennleistung, während die Last auf Empfehlung/Ansteuerung der Integration läuft. Hält die Abweichung länger als 30 Minuten an (z. B. Wassertank voll: nahe 0 W), geht der Warnsensor der Last auf „Problem“. 0 = deaktiviert. Kurze Abtau-Pausen bleiben unterhalb der 30 Minuten und lösen nicht aus.",
+            "power_warning_percent": "Warnschwelle für die Abweichung zwischen realer Leistung und Nennleistung, während die Last auf Empfehlung/Ansteuerung der Integration läuft. Hält die Abweichung länger als die Verzögerung unten an (z. B. Wassertank voll: nahe 0 W), geht der Warnsensor der Last auf „Problem“ und bleibt an, bis die Last wieder mit ihrer Nennleistung läuft. 0 = deaktiviert (Standard für neue Lasten). Kurze Abtau-Pausen setzen den Timer zurück und lösen nicht aus.",
             "control_switch_entity": "Schaltbare Steckdose/Relais, die die Last mit Strom versorgt; wenn gesetzt, schaltet BM die Last selbst ein und aus, und eine eigene Schalt-Automation wird überflüssig. Bei einer Powerstation ist das der Ladeeingang.",
-            "input_off_policy": "Was mit der Steckdose passiert, wenn BM die Last abschaltet. „Automatisch“ = nur ausschalten, wenn BM sie selbst eingeschaltet hat — empfohlen, wenn die Steckdose auch für Passthrough genutzt wird."
+            "input_off_policy": "Was mit der Steckdose passiert, wenn BM die Last abschaltet. „Automatisch“ = nur ausschalten, wenn BM sie selbst eingeschaltet hat — empfohlen, wenn die Steckdose auch für Passthrough genutzt wird.",
+            "power_warning_dwell_min": "Wie lange die Abweichung anhalten muss, bevor die Warnung angeht. Überbrückt kurze Abtau-Pausen; ein kleinerer Wert warnt früher. Standard 15."
           }
         },
         "reconfigure": {
@@ -323,7 +325,8 @@
             "in_house_measurement": "In Hauslast-Messung enthalten",
             "power_warning_percent": "Leistungsabweichungs-Warnung (%)",
             "control_switch_entity": "Steuerschalter / Steckdose (optional — BM schaltet direkt)",
-            "input_off_policy": "Steckdose beim Abschalten"
+            "input_off_policy": "Steckdose beim Abschalten",
+            "power_warning_dwell_min": "Verzögerung Leistungswarnung (Min.)"
           },
           "data_description": {
             "name": "Anzeigename der Last — erscheint im Untereintrag und im Namen der Empfehlungs-Entität.",
@@ -336,9 +339,10 @@
             "power_entity": "Sensor mit der real gemessenen Aufnahmeleistung. Ersetzt (geglättet) die Nennleistung in der Planung, sobald Messwerte vorliegen.",
             "availability_entity": "Die Last wird nur eingeplant, wenn diese Entität an/verfügbar ist — z. B. ein input_boolean als manueller Freigabeschalter. Bei off/unavailable/unknown wird die Last ignoriert.",
             "in_house_measurement": "Eingeschaltet lassen, wenn diese Last hinter dem konfigurierten Verbrauchs-Messpunkt hängt — sie wird dann beim Lernen der Grundlast herausgerechnet. Ausschalten, wenn die Last außerhalb versorgt wird (z. B. über einen Einspeise-Sollwert): Sonst würde sie doppelt abgezogen.",
-            "power_warning_percent": "Warnschwelle für die Abweichung zwischen realer Leistung und Nennleistung, während die Last auf Empfehlung/Ansteuerung der Integration läuft. Hält die Abweichung länger als 30 Minuten an (z. B. Wassertank voll: nahe 0 W), geht der Warnsensor der Last auf „Problem“. 0 = deaktiviert. Kurze Abtau-Pausen bleiben unterhalb der 30 Minuten und lösen nicht aus.",
+            "power_warning_percent": "Warnschwelle für die Abweichung zwischen realer Leistung und Nennleistung, während die Last auf Empfehlung/Ansteuerung der Integration läuft. Hält die Abweichung länger als die Verzögerung unten an (z. B. Wassertank voll: nahe 0 W), geht der Warnsensor der Last auf „Problem“ und bleibt an, bis die Last wieder mit ihrer Nennleistung läuft. 0 = deaktiviert (Standard für neue Lasten). Kurze Abtau-Pausen setzen den Timer zurück und lösen nicht aus.",
             "control_switch_entity": "Schaltbare Steckdose/Relais, die die Last mit Strom versorgt; wenn gesetzt, schaltet BM die Last selbst ein und aus, und eine eigene Schalt-Automation wird überflüssig. Bei einer Powerstation ist das der Ladeeingang.",
-            "input_off_policy": "Was mit der Steckdose passiert, wenn BM die Last abschaltet. „Automatisch“ = nur ausschalten, wenn BM sie selbst eingeschaltet hat — empfohlen, wenn die Steckdose auch für Passthrough genutzt wird."
+            "input_off_policy": "Was mit der Steckdose passiert, wenn BM die Last abschaltet. „Automatisch“ = nur ausschalten, wenn BM sie selbst eingeschaltet hat — empfohlen, wenn die Steckdose auch für Passthrough genutzt wird.",
+            "power_warning_dwell_min": "Wie lange die Abweichung anhalten muss, bevor die Warnung angeht. Überbrückt kurze Abtau-Pausen; ein kleinerer Wert warnt früher. Standard 15."
           }
         },
         "storage": {
@@ -580,6 +584,18 @@
               "psu48_on_voltage_v": "Bei manuellem 48-V-Betrieb: unterhalb dieser Batteriespannung schaltet der Regler das Netzteil EIN. Benötigt den Batteriespannungs-Sensor.",
               "psu48_off_voltage_v": "Bei manuellem 48-V-Betrieb: ab dieser Batteriespannung schaltet der Regler das Netzteil AUS. Muss über der Einschalt-Spannung liegen (Hysterese).",
               "psu48_controller_log_only": "An = Regler protokolliert nur seine Entscheidungen, schaltet aber nicht (Testlauf). Aus = Regler schaltet das 48-V-Netzteil aktiv."
+            }
+          },
+          "notifications": {
+            "name": "Benachrichtigungen bei Leistungswarnung",
+            "description": "Sende eine Smartphone-Benachrichtigung, wenn die Leistungswarnung einer Last angeht (und, sofern nicht abgeschaltet, wenn sie sich löst).",
+            "data": {
+              "power_warning_notify_targets": "Benachrichtigungsziele",
+              "power_warning_notify_on_resolve": "Auch bei Behebung benachrichtigen"
+            },
+            "data_description": {
+              "power_warning_notify_targets": "Die Smartphones/Notify-Dienste, die alarmiert werden (z. B. eure Home-Assistant-Companion-Apps). Ein Ziel pro Person hinzufügen, die benachrichtigt werden soll. Leer = keine Push-Nachricht.",
+              "power_warning_notify_on_resolve": "Sende eine weitere Benachrichtigung, sobald die Last wieder mit ihrer Nennleistung läuft."
             }
           }
         }

--- a/custom_components/battery_manager/translations/en.json
+++ b/custom_components/battery_manager/translations/en.json
@@ -290,7 +290,8 @@
             "in_house_measurement": "Included in house-load measurement",
             "power_warning_percent": "Power deviation warning (%)",
             "control_switch_entity": "Control switch / plug (optional — BM switches it directly)",
-            "input_off_policy": "Plug when switching off"
+            "input_off_policy": "Plug when switching off",
+            "power_warning_dwell_min": "Power warning dwell (min)"
           },
           "data_description": {
             "name": "Display name of the load — appears in the sub-entry and in the recommendation entity's name.",
@@ -303,9 +304,10 @@
             "power_entity": "Sensor with the actually measured power draw. Replaces (smoothed) the nominal power in planning once readings are available.",
             "availability_entity": "The load is only scheduled while this entity is on/available — e.g. an input_boolean as a manual enable switch. off/unavailable/unknown = the load is ignored.",
             "in_house_measurement": "Keep enabled if this load sits behind the configured consumption measuring point — it is then subtracted while learning the baseline. Disable if the load is supplied outside of it (e.g. via a feed-in setpoint): otherwise it would be subtracted twice.",
-            "power_warning_percent": "Warning threshold for the deviation between real draw and the configured power while the load runs at the integration's request. If the deviation persists for more than 30 minutes (e.g. full water tank: near 0 W), the load's warning sensor turns on. 0 = disabled. Short defrost pauses stay below the 30 minutes and do not trigger.",
+            "power_warning_percent": "Warning threshold for the deviation between real draw and the configured power while the load runs at the integration's request. If the deviation persists longer than the dwell below (e.g. full water tank: near 0 W), the load's warning sensor turns on and stays on until the load runs at its configured power again. 0 = disabled (the default for new loads). Short defrost pauses reset the timer and do not trigger.",
             "control_switch_entity": "Switchable plug/relay that powers the load; if set, BM turns the load on and off itself and a separate switching automation becomes redundant. For a powerstation this is the charging input.",
-            "input_off_policy": "What happens to the plug when BM stops the load. \"Automatic\" = only switch off if BM switched it on itself — recommended when the plug is also used for passthrough."
+            "input_off_policy": "What happens to the plug when BM stops the load. \"Automatic\" = only switch off if BM switched it on itself — recommended when the plug is also used for passthrough.",
+            "power_warning_dwell_min": "How long the deviation must persist before the warning turns on. Rides through short defrost pauses; a shorter value warns sooner. Default 15."
           }
         },
         "reconfigure": {
@@ -323,7 +325,8 @@
             "in_house_measurement": "Included in house-load measurement",
             "power_warning_percent": "Power deviation warning (%)",
             "control_switch_entity": "Control switch / plug (optional — BM switches it directly)",
-            "input_off_policy": "Plug when switching off"
+            "input_off_policy": "Plug when switching off",
+            "power_warning_dwell_min": "Power warning dwell (min)"
           },
           "data_description": {
             "name": "Display name of the load — appears in the sub-entry and in the recommendation entity's name.",
@@ -336,9 +339,10 @@
             "power_entity": "Sensor with the actually measured power draw. Replaces (smoothed) the nominal power in planning once readings are available.",
             "availability_entity": "The load is only scheduled while this entity is on/available — e.g. an input_boolean as a manual enable switch. off/unavailable/unknown = the load is ignored.",
             "in_house_measurement": "Keep enabled if this load sits behind the configured consumption measuring point — it is then subtracted while learning the baseline. Disable if the load is supplied outside of it (e.g. via a feed-in setpoint): otherwise it would be subtracted twice.",
-            "power_warning_percent": "Warning threshold for the deviation between real draw and the configured power while the load runs at the integration's request. If the deviation persists for more than 30 minutes (e.g. full water tank: near 0 W), the load's warning sensor turns on. 0 = disabled. Short defrost pauses stay below the 30 minutes and do not trigger.",
+            "power_warning_percent": "Warning threshold for the deviation between real draw and the configured power while the load runs at the integration's request. If the deviation persists longer than the dwell below (e.g. full water tank: near 0 W), the load's warning sensor turns on and stays on until the load runs at its configured power again. 0 = disabled (the default for new loads). Short defrost pauses reset the timer and do not trigger.",
             "control_switch_entity": "Switchable plug/relay that powers the load; if set, BM turns the load on and off itself and a separate switching automation becomes redundant. For a powerstation this is the charging input.",
-            "input_off_policy": "What happens to the plug when BM stops the load. \"Automatic\" = only switch off if BM switched it on itself — recommended when the plug is also used for passthrough."
+            "input_off_policy": "What happens to the plug when BM stops the load. \"Automatic\" = only switch off if BM switched it on itself — recommended when the plug is also used for passthrough.",
+            "power_warning_dwell_min": "How long the deviation must persist before the warning turns on. Rides through short defrost pauses; a shorter value warns sooner. Default 15."
           }
         },
         "storage": {
@@ -580,6 +584,18 @@
               "psu48_on_voltage_v": "In manual 48 V mode: below this battery voltage the controller switches the PSU ON. Requires the battery voltage sensor.",
               "psu48_off_voltage_v": "In manual 48 V mode: at or above this battery voltage the controller switches the PSU OFF. Must be above the turn-on voltage (hysteresis).",
               "psu48_controller_log_only": "On = controller only logs its decisions without switching (dry run). Off = controller actively switches the 48 V PSU."
+            }
+          },
+          "notifications": {
+            "name": "Power-warning notifications",
+            "description": "Push a smartphone notification when any load's power warning turns on (and, unless silenced, when it clears).",
+            "data": {
+              "power_warning_notify_targets": "Notify targets",
+              "power_warning_notify_on_resolve": "Also notify when resolved"
+            },
+            "data_description": {
+              "power_warning_notify_targets": "The phones/notify services to alert (e.g. your Home Assistant companion apps). Add one per person who should be notified. Empty = no push.",
+              "power_warning_notify_on_resolve": "Send a follow-up notification when the load runs at its configured power again."
             }
           }
         }

--- a/docs/LOAD_CONTROL.md
+++ b/docs/LOAD_CONTROL.md
@@ -148,20 +148,32 @@ SOC (ground truth) anyway, not integrated over the power.
   charging — after charge end, the taper residual (10–40 W) would otherwise
   permanently weaken all gates as "measured" planning power. The log lines
   "Charging started/stopped" name the plain-text load name.
-- **F-L7 (2026-07-05): power-deviation warning per load.** The dehumidifier
-  periodically defrosts briefly (power drops for minutes) and stops entirely
-  when the water tank is full (power near 0 W despite an active
+- **F-L7 (2026-07-05, extended 2026-07-12): power-deviation warning per load.**
+  The dehumidifier periodically defrosts briefly (power drops for minutes) and
+  stops entirely when the water tank is full (power near 0 W despite an active
   recommendation). Defrost cycles may enter the power average (samples between
   the standby threshold and the rated power average the EMA; below that the
   sample is discarded and the EMA is frozen — "totally ruining it" is
   precluded by the 25 % threshold). But if the real power deviates for **longer
-  than 30 minutes** by more than the configured percentage (field "power-
-  deviation warning", default 50 %, 0 = off) from the rated power while the
-  load is running at the integration's instigation, the load's new warning
-  sensor (`binary_sensor … power warning`, device class `problem`) goes on —
-  as a trigger for user notifications (empty the tank, correct the rated power,
-  foreign load). Short defrost pauses reset the timer and do not fire; manual
-  operation never fires (F-L6 logic).
+  than the per-load dwell** (field "power warning dwell", default 15 min) by
+  more than the configured percentage (field "power-deviation warning", default
+  **0 % = off**; the operator opts a load in per device — an existing load keeps
+  its stored value) from the rated power while the load is running at the
+  integration's instigation, the load's warning sensor (`binary_sensor … power
+  warning`, device class `problem`) goes on. Short defrost pauses reset the
+  timer and do not fire; manual operation never fires (F-L6 logic).
+  - **Latching (operator wish 2026-07-12).** Once on, the warning stays on
+    until the load runs at its configured power **again at the integration's
+    request** — it does NOT clear merely because BM stops requesting the load
+    (a full tank is still full while the load is off). The latch is persisted,
+    so an options save (which reloads the coordinator) or a restart does not
+    silently drop it; only the bool is persisted, so a not-yet-tripped dwell
+    re-arms after a restart.
+  - **Push notifications (operator wish 2026-07-12).** A single global list of
+    `notify` targets (integration Options → *Power-warning notifications*, e.g.
+    each person's companion app) is pushed to when any load's warning trips,
+    and — unless silenced — when it clears. Empty list = no push; the
+    `binary_sensor` remains available for custom automations either way.
 - **F-L6 (2026-07-05): manual activations do not influence planning.** The
   operator occasionally switches loads (or rather their metered socket) by
   hand — e.g. the dehumidifier, or a foreign load on the same socket. Feedback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "battery-manager-ha"
-version = "0.11.2"
+version = "0.12.0"
 description = "Solar-battery optimizer for Home Assistant: SOC forecast, discharge-threshold planning, surplus-load and grid-support control."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/ha/test_config_flow.py
+++ b/tests/ha/test_config_flow.py
@@ -136,6 +136,7 @@ async def test_options_flow_flattens_sections_on_submit(hass):
                 "battery_cells_series": 15,
                 "gate_soc_percent": 100.0,
             },
+            "notifications": {},
         },
     )
     assert result["type"] == "create_entry"
@@ -202,6 +203,7 @@ async def test_options_flow_rejects_inverted_controller_band(hass):
                 "psu48_off_voltage_v": 49.56,
                 "psu48_controller_log_only": False,
             },
+            "notifications": {},
         },
     )
     assert result["type"] == "form"
@@ -258,6 +260,7 @@ async def test_options_flow_rejects_bad_support_hysteresis(hass):
                 "battery_cells_series": 15,
                 "gate_soc_percent": 100.0,
             },
+            "notifications": {},
         }
 
     async def submit(support_extra):
@@ -1066,3 +1069,63 @@ async def test_reconfigure_repoints_pv_and_preserves_everything_else(hass):
         if sub.subentry_type == SUBENTRY_TYPE_LOAD
     ] == load_ids
     assert entry.subentries[load_ids[0]].data[CONF_LOAD_POWER_W] == 300.0
+
+
+def test_notify_services_filters_non_targets(hass):
+    """The notify-target picker offers push services (mobile_app_*) but hides
+    the non-target dispatchers (send_message needs an entity_id; the
+    persistent_notification service is not a phone)."""
+    from custom_components.battery_manager.config_flow import _notify_services
+
+    async def _noop(call):
+        return None
+
+    for name in ("mobile_app_pixel", "send_message", "persistent_notification"):
+        hass.services.async_register("notify", name, _noop)
+
+    offered = _notify_services(hass)
+    assert "mobile_app_pixel" in offered
+    assert "send_message" not in offered
+    assert "persistent_notification" not in offered
+
+
+async def test_options_flow_renders_notifications_section(hass):
+    """The new notifications section renders (schema construction must not
+    raise) and carries the notify-targets + resolve-toggle fields."""
+    from custom_components.battery_manager.const import (
+        CONF_WARNING_NOTIFY_ON_RESOLVE,
+        CONF_WARNING_NOTIFY_TARGETS,
+    )
+
+    entry = await _setup_entry(hass)
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    fields = {
+        str(k) for k in _section_fields(result["data_schema"].schema, "notifications")
+    }
+    assert CONF_WARNING_NOTIFY_TARGETS in fields
+    assert CONF_WARNING_NOTIFY_ON_RESOLVE in fields
+
+
+async def test_options_flow_stores_notify_targets(hass):
+    """The notify targets + resolve toggle round-trip and are stored flat
+    (the coordinator reads them from a flat raw_config)."""
+    from custom_components.battery_manager.const import (
+        CONF_WARNING_NOTIFY_ON_RESOLVE,
+        CONF_WARNING_NOTIFY_TARGETS,
+    )
+
+    entry = await _setup_entry(hass)
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    payload = _no_change_options_payload(result["data_schema"].schema)
+    payload["notifications"] = {
+        CONF_WARNING_NOTIFY_TARGETS: ["mobile_app_alice", "mobile_app_bob"],
+        CONF_WARNING_NOTIFY_ON_RESOLVE: False,
+    }
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], payload
+    )
+    assert result["type"] == "create_entry"
+    opts = result["data"]
+    assert opts[CONF_WARNING_NOTIFY_TARGETS] == ["mobile_app_alice", "mobile_app_bob"]
+    assert opts[CONF_WARNING_NOTIFY_ON_RESOLVE] is False
+    assert "notifications" not in opts  # section wrapper flattened away

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -787,6 +787,28 @@ async def test_load_plan_dict_carries_why_and_learned_power(hass):
     assert sensor_schedule and all("why" in row for row in sensor_schedule)
 
 
+async def test_refresh_awaits_power_warning_update(hass):
+    """Async-seam guard (0.12.0): _async_update_data must AWAIT the now-async
+    _update_power_warnings. A dropped `await` would leave the coroutine
+    unscheduled — power warnings, the persisted latch and push notifications
+    would silently stop — yet the unit tests that call the method directly
+    stay green. Drive a real refresh and assert the method actually ran."""
+    coordinator, _titles = await _setup_entry_with_load_data(
+        hass, [("F1", {"power_w": 300.0})]
+    )
+    ran: list[bool] = []
+    real = coordinator._update_power_warnings
+
+    async def _wrapped(result, now):
+        ran.append(True)
+        return await real(result, now)
+
+    coordinator._update_power_warnings = _wrapped
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    assert ran, "_async_update_data must await _update_power_warnings"
+
+
 # ---------------------------------------------------------------------------
 # F-PERDAY-SURPLUS: per-calendar-day lost-surplus / grid-import breakdown
 # (docs/F-PERDAY-SURPLUS.md R1-R3).

--- a/tests/ha/test_load_switching.py
+++ b/tests/ha/test_load_switching.py
@@ -19,12 +19,16 @@ from custom_components.battery_manager.const import (
     CONF_LOAD_MIN_RUNTIME_MIN,
     CONF_LOAD_POWER_ENTITY,
     CONF_LOAD_POWER_W,
+    CONF_LOAD_POWER_WARNING_DWELL_MIN,
+    CONF_LOAD_POWER_WARNING_PCT,
     CONF_LOAD_SOC_ENTITY,
     CONF_LOAD_TARGET_SOC,
     CONF_PV_FORECAST_DAY_AFTER,
     CONF_PV_FORECAST_TODAY,
     CONF_PV_FORECAST_TOMORROW,
     CONF_SOC_ENTITY,
+    CONF_WARNING_NOTIFY_ON_RESOLVE,
+    CONF_WARNING_NOTIFY_TARGETS,
     DOMAIN,
     INPUT_OFF_POLICY_ALWAYS,
     INPUT_OFF_POLICY_AUTO,
@@ -71,6 +75,8 @@ async def _setup(
     min_off_min=None,
     power_entity=POWER_FEEDBACK,
     charge_enable=ENABLE,
+    power_warning_pct=50.0,
+    power_warning_dwell_min=30,
 ):
     hass.states.async_set(
         "sensor.test_soc", "55", {"unit_of_measurement": "%", "device_class": "battery"}
@@ -87,6 +93,8 @@ async def _setup(
         CONF_LOAD_CAPACITY_WH: 2000.0,
         CONF_LOAD_TARGET_SOC: 90.0,
         CONF_LOAD_SOC_ENTITY: FOSSI_SOC,
+        CONF_LOAD_POWER_WARNING_PCT: power_warning_pct,
+        CONF_LOAD_POWER_WARNING_DWELL_MIN: power_warning_dwell_min,
     }
     if power_entity is not None:
         load_data[CONF_LOAD_POWER_ENTITY] = power_entity
@@ -449,14 +457,14 @@ async def test_power_warning_after_sustained_deviation(hass):
     t0 = dt_util.utcnow()
 
     hass.states.async_set(POWER_FEEDBACK, "2")  # tank full
-    coordinator._update_power_warnings(result, t0)
+    await coordinator._update_power_warnings(result, t0)
     assert coordinator._load_power_warning.get(sub_id, False) is False
 
-    coordinator._update_power_warnings(result, t0 + timedelta(minutes=31))
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=31))
     assert coordinator._load_power_warning[sub_id] is True
 
     hass.states.async_set(POWER_FEEDBACK, "395")  # back to normal
-    coordinator._update_power_warnings(result, t0 + timedelta(minutes=40))
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=40))
     assert coordinator._load_power_warning[sub_id] is False
 
 
@@ -474,12 +482,12 @@ async def test_power_warning_defrost_dip_resets_timer(hass):
     t0 = dt_util.utcnow()
 
     hass.states.async_set(POWER_FEEDBACK, "150")  # defrost: fan + heater
-    coordinator._update_power_warnings(result, t0)
+    await coordinator._update_power_warnings(result, t0)
     hass.states.async_set(POWER_FEEDBACK, "400")  # compressor back on
-    coordinator._update_power_warnings(result, t0 + timedelta(minutes=10))
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=10))
     hass.states.async_set(POWER_FEEDBACK, "150")  # next defrost
-    coordinator._update_power_warnings(result, t0 + timedelta(minutes=45))
-    coordinator._update_power_warnings(result, t0 + timedelta(minutes=60))
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=45))
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=60))
     # Second dip lasted only 15 min since its own start: no warning.
     assert coordinator._load_power_warning.get(sub_id, False) is False
 
@@ -499,16 +507,308 @@ async def test_power_warning_ignores_manual_runs(hass):
     t0 = dt_util.utcnow()
 
     hass.states.async_set(POWER_FEEDBACK, "800")  # foreign consumer
-    coordinator._update_power_warnings(result, t0)
-    coordinator._update_power_warnings(result, t0 + timedelta(minutes=45))
+    await coordinator._update_power_warnings(result, t0)
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=45))
     assert coordinator._load_power_warning.get(sub_id, False) is False
 
     # With an active recommendation the same deviation IS a problem.
     active_plan = SimpleNamespace(load_id=sub_id, active_now=True)
     result = SimpleNamespace(load_plans=[active_plan])
-    coordinator._update_power_warnings(result, t0 + timedelta(minutes=50))
-    coordinator._update_power_warnings(result, t0 + timedelta(minutes=81))
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=50))
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=81))
     assert coordinator._load_power_warning[sub_id] is True
+
+
+async def test_power_warning_dwell_is_per_load_configurable(hass):
+    """The dwell is a per-load setting: a 15-min dwell trips after 15 min,
+    not after the old fixed 30 (operator wish 2026-07-12)."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(
+        hass, calls, power_w=400.0, power_warning_dwell_min=15
+    )
+    result = SimpleNamespace(load_plans=[])
+    coordinator._load_charging_active[sub_id] = True
+    t0 = dt_util.utcnow()
+
+    hass.states.async_set(POWER_FEEDBACK, "2")  # tank full
+    await coordinator._update_power_warnings(result, t0)
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=14))
+    assert coordinator._load_power_warning.get(sub_id, False) is False  # < 15
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=16))
+    assert coordinator._load_power_warning[sub_id] is True  # >= 15
+
+
+async def test_power_warning_disabled_at_zero_percent(hass):
+    """0 % = off: a sustained deviation never trips (the new default for a
+    freshly added load)."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(
+        hass, calls, power_w=400.0, power_warning_pct=0.0
+    )
+    result = SimpleNamespace(load_plans=[])
+    coordinator._load_charging_active[sub_id] = True
+    t0 = dt_util.utcnow()
+
+    hass.states.async_set(POWER_FEEDBACK, "2")  # tank full
+    await coordinator._update_power_warnings(result, t0)
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=60))
+    assert coordinator._load_power_warning.get(sub_id, False) is False
+
+
+async def test_power_warning_latches_when_deactivated(hass):
+    """Regression (operator report 2026-07-12): once tripped, the warning
+    stays on when the load is deactivated (BM stops requesting it) — a full
+    tank is still full while the load is off — and clears only when the load
+    runs at its configured power again."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, power_w=400.0)
+    result = SimpleNamespace(load_plans=[])
+    coordinator._load_charging_active[sub_id] = True
+    t0 = dt_util.utcnow()
+
+    # Trip the warning while active.
+    hass.states.async_set(POWER_FEEDBACK, "2")  # tank full
+    await coordinator._update_power_warnings(result, t0)
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=31))
+    assert coordinator._load_power_warning[sub_id] is True
+
+    # Deactivate the load (BM no longer requests it): the OLD behaviour cleared
+    # the warning here — it must now LATCH on.
+    coordinator._load_charging_active[sub_id] = False
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=40))
+    assert coordinator._load_power_warning[sub_id] is True
+
+    # Even a normal reading while inactive must NOT clear it (not BM-driven).
+    hass.states.async_set(POWER_FEEDBACK, "400")
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=50))
+    assert coordinator._load_power_warning[sub_id] is True
+
+    # Only running at configured power AT BM'S REQUEST clears it.
+    coordinator._load_charging_active[sub_id] = True
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=60))
+    assert coordinator._load_power_warning[sub_id] is False
+
+
+async def test_power_warning_latch_survives_reload(hass):
+    """The latch is persisted so an options save (coordinator reload) or a
+    restart does not silently drop a raised warning; a vanished subentry is
+    dropped on restore."""
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, power_w=400.0)
+
+    coordinator._load_power_warning = {sub_id: True, "vanished_sub": True}
+    payload = coordinator._persistent_payload()
+    assert payload["load_power_warning"] == {sub_id: True, "vanished_sub": True}
+
+    await coordinator._store.async_save(payload)
+    coordinator._load_power_warning = {}
+    await coordinator.async_load_persistent_state()
+    # Restored for the live subentry, dropped for the vanished one.
+    assert coordinator._load_power_warning == {sub_id: True}
+
+
+async def test_power_warning_latch_cleared_when_disabled(hass):
+    """Turning the warning off (0 %) drops a lingering latch and dwell timer,
+    so it can never get stuck invisibly once the feature is disabled."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(
+        hass, calls, power_w=400.0, power_warning_pct=0.0
+    )
+    coordinator._load_power_warning[sub_id] = True
+    coordinator._load_deviation_since[sub_id] = dt_util.utcnow()
+    result = SimpleNamespace(load_plans=[])
+    coordinator._load_charging_active[sub_id] = True
+
+    await coordinator._update_power_warnings(result, dt_util.utcnow())
+    assert coordinator._load_power_warning.get(sub_id, False) is False
+    assert sub_id not in coordinator._load_deviation_since
+
+
+async def test_power_warning_pushes_notifications(hass):
+    """The trip edge pushes a 'problem' notification to every configured
+    target (with load name + measured/expected W); the clear edge pushes a
+    'resolved' notification. Driven through _set_power_warning to keep the
+    edge->notify wiring deterministic (the coordinator's refresh machinery
+    resets manual _load_charging_active across async_block_till_done)."""
+    captured: list[dict] = []
+
+    async def _fake_notify(call):
+        captured.append(dict(call.data))
+
+    hass.services.async_register("notify", "mobile_app_test", _fake_notify)
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, power_w=400.0)
+    coordinator.raw_config[CONF_WARNING_NOTIFY_TARGETS] = ["mobile_app_test"]
+    coordinator.raw_config[CONF_WARNING_NOTIFY_ON_RESOLVE] = True
+
+    # Trip edge.
+    await coordinator._set_power_warning(
+        sub_id, "Fossibot Test", True, raw=2, nominal=400, dwell=30
+    )
+    await hass.async_block_till_done()
+    assert len(captured) == 1
+    assert "power warning" in captured[0]["title"].lower()
+    assert "Fossibot Test" in captured[0]["message"]
+    assert "400 W" in captured[0]["message"]
+
+    # Clear edge.
+    await coordinator._set_power_warning(sub_id, "Fossibot Test", False)
+    await hass.async_block_till_done()
+    assert len(captured) == 2
+    assert "cleared" in captured[1]["title"].lower()
+
+
+async def test_power_warning_notifies_all_targets(hass):
+    """A global list with several targets pushes to each (arbitrary users)."""
+    captured: list[tuple[str, dict]] = []
+
+    def _make(name):
+        async def _fake_notify(call):
+            captured.append((name, dict(call.data)))
+
+        return _fake_notify
+
+    for name in ("mobile_app_a", "mobile_app_b"):
+        hass.services.async_register("notify", name, _make(name))
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, power_w=400.0)
+    coordinator.raw_config[CONF_WARNING_NOTIFY_TARGETS] = [
+        "mobile_app_a",
+        "mobile_app_b",
+    ]
+
+    await coordinator._set_power_warning(
+        sub_id, "Fossibot Test", True, raw=2, nominal=400, dwell=30
+    )
+    await hass.async_block_till_done()
+    assert {name for name, _ in captured} == {"mobile_app_a", "mobile_app_b"}
+
+
+async def test_power_warning_resolve_notification_can_be_silenced(hass):
+    """With the resolve toggle off, the clear edge sends no push (the trip
+    still does)."""
+    captured: list[dict] = []
+
+    async def _fake_notify(call):
+        captured.append(dict(call.data))
+
+    hass.services.async_register("notify", "mobile_app_test", _fake_notify)
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, power_w=400.0)
+    coordinator.raw_config[CONF_WARNING_NOTIFY_TARGETS] = ["mobile_app_test"]
+    coordinator.raw_config[CONF_WARNING_NOTIFY_ON_RESOLVE] = False
+
+    await coordinator._set_power_warning(
+        sub_id, "Fossibot Test", True, raw=2, nominal=400, dwell=30
+    )
+    await coordinator._set_power_warning(sub_id, "Fossibot Test", False)
+    await hass.async_block_till_done()
+    assert len(captured) == 1  # trip only, no resolve push
+
+
+async def test_power_warning_no_targets_no_push(hass):
+    """No configured targets -> no service call attempted (no-op), even though
+    a notify service exists."""
+    seen: list[dict] = []
+
+    async def _spy(call):
+        seen.append(dict(call.data))
+
+    hass.services.async_register("notify", "mobile_app_spy", _spy)
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, power_w=400.0)
+    coordinator.raw_config[CONF_WARNING_NOTIFY_TARGETS] = []
+    await coordinator._set_power_warning(
+        sub_id, "Fossibot Test", True, raw=2, nominal=400, dwell=30
+    )
+    await hass.async_block_till_done()
+    assert coordinator._load_power_warning[sub_id] is True
+    assert seen == []  # the registered service was NOT invoked
+
+
+async def test_power_warning_notify_isolates_bad_target(hass):
+    """A stale/removed target (ServiceNotFound is raised synchronously even
+    with blocking=False) must neither escape into the update cycle nor block
+    the remaining good targets — the per-target try/except is load-bearing."""
+    captured: list[dict] = []
+
+    async def _ok(call):
+        captured.append(dict(call.data))
+
+    hass.services.async_register("notify", "mobile_app_good", _ok)
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, power_w=400.0)
+    # 'mobile_app_deleted' is not registered (e.g. a since-removed phone) and
+    # is listed FIRST — it must not stop the good target that follows.
+    coordinator.raw_config[CONF_WARNING_NOTIFY_TARGETS] = [
+        "mobile_app_deleted",
+        "mobile_app_good",
+    ]
+    # Awaited directly: an un-caught ServiceNotFound would raise HERE (which is
+    # exactly how it would break _async_update_data in production).
+    await coordinator._set_power_warning(
+        sub_id, "Fossibot Test", True, raw=2, nominal=400, dwell=30
+    )
+    await hass.async_block_till_done()
+    assert len(captured) == 1  # the good target still received the push
+
+
+async def test_power_warning_notifies_through_update_cycle(hass):
+    """The trip push also fires when reached through the production method
+    _update_power_warnings (not just _set_power_warning directly), and the
+    real raw/nominal/dwell values flow into the message. No block_till_done
+    between the two updates, so the coordinator machinery cannot reset the
+    manually-driven active state mid-test."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    captured: list[dict] = []
+
+    async def _fake_notify(call):
+        captured.append(dict(call.data))
+
+    hass.services.async_register("notify", "mobile_app_test", _fake_notify)
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(
+        hass, calls, power_w=400.0, power_warning_dwell_min=15
+    )
+    coordinator.raw_config[CONF_WARNING_NOTIFY_TARGETS] = ["mobile_app_test"]
+    result = SimpleNamespace(load_plans=[])
+    t0 = dt_util.utcnow()
+
+    hass.states.async_set(POWER_FEEDBACK, "2")  # tank full
+    coordinator._load_charging_active[sub_id] = True
+    await coordinator._update_power_warnings(result, t0)
+    coordinator._load_charging_active[sub_id] = True
+    await coordinator._update_power_warnings(result, t0 + timedelta(minutes=16))
+    await hass.async_block_till_done()
+    assert len(captured) == 1
+    assert "Fossibot Test" in captured[0]["message"]
+    assert "400 W" in captured[0]["message"]
+    assert "15 min" in captured[0]["message"]  # per-load dwell in the text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Triggered by the operator's 2026-07-12 dehumidifier report (F-L7).

## What changed
- **Per-load power-warning dwell** — new `power_warning_dwell_min` field, default **15 min** (was a fixed 30-min module constant). Halves the reported ~33-min delay for the dehumidifier.
- **Warning off by default** — deviation-% default `50 → 0`; the operator opts each load in. Existing loads keep their stored value, so an already-warning load (the dehumidifier) stays on.
- **The warning now latches** — it clears only when the load runs at its configured power again *at BM's request*, not when BM stops requesting it (a full tank is still full while the load is off). The latch bool is persisted (`_persistent_payload`/`async_load_persistent_state`), so an options save (coordinator reload) or restart no longer drops a raised warning. Disabling the warning (`pct=0`) or removing the power sensor drops a lingering latch.
- **Built-in push notifications** — a single global list of `notify` targets + a resolve toggle (Options → *Power-warning notifications*). Push on trip and, unless silenced, on clear. `_update_power_warnings`/`_set_power_warning` are now `async`; `_notify_power_warning` sends per-target with a load-bearing try/except so a stale/removed target can't stall the update cycle or block other targets.

## Verification
- Full HA suite green (~351 tests, run under WSL); `ruff check` + `ruff format --check` clean; `manifest.json` == `pyproject.toml` == `0.12.0`.
- Adversarial multi-agent review (17 agents): **0 correctness bugs**. Its 4 confirmed findings were all test-coverage gaps, now covered by added tests (async-seam guard, stale-target isolation, notify-through-`_update_power_warnings`, options round-trip).

Docs: `docs/LOAD_CONTROL.md` F-L7 updated; `CHANGELOG.md` under 0.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)