### PR TITLE
Release v0.13.0: gate parity — priority decides, for both load classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-18
+
+### Changed
+- **Gate parity: priority always wins over load class (F-GATE-PARITY,
+  operator decision 2026-07-17).** Energy-limited loads (Fossibot
+  powerstations) now face the IDENTICAL pass-2 gate set as continuous
+  loads — the shared Z2' import-trade invariant (anchored at the no-loads
+  base), the rt-honest c1 refill gate, the optimistic c2 (beta) in-window
+  insurance and the Z4 windowed stress floor. The former class carve-out
+  (strict no-extra-import, c1-only) let a lower-priority dehumidifier take
+  make-room/battery-share bet energy a higher-priority powerstation was
+  forbidden, silently overriding the configured load priority. Now the
+  priority (config order) alone decides contested energy. The single
+  remaining class rule: energy-limited loads never book zero-PV (night)
+  slots — nights stay reserved for continuous loads.
+  Consequences to expect live: a hungry powerstation may now consume the
+  trade/c2 budget ahead of the dehumidifier (its make-room and night
+  pre-drain hours can shrink accordingly — intended), and powerstation
+  charging may cause small traded grid import within the shared
+  `import_trade_ratio` budget.
+- **`stressed_min_soc` diagnostic covers all loads.** The SOC-forecast
+  attribute now reports the stressed reserve of the earliest pass-2 booking
+  of ANY load (previously continuous-only); the value may shift after the
+  update — observability only.
+- Golden `short_peak_preempt`: the powerstation's pre-window pass-2 hours
+  sat in zero-PV (two-window model) morning hours and are now barred by the
+  night rule (planned energy 1800 → 900 Wh in that synthetic scenario;
+  import unchanged). With real hourly forecasts, morning hours carry light
+  and pre-window pre-charges remain available — the adapted tests model
+  this with a 5 Wh dawn-shoulder (`_twilight`).
+
 ## [0.12.0] - 2026-07-12
 
 ### Added

--- a/custom_components/battery_manager/coordinator.py
+++ b/custom_components/battery_manager/coordinator.py
@@ -961,13 +961,18 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _log_night_predrain(self, result, inputs, config: SystemConfig) -> None:
         """One INFO line when the plan books preemptive night charging.
 
-        A pre-drain "make room" run (pass 2) for a CONTINUOUS load that lands
-        OUTSIDE every PV absorption window is the F-PREDRAIN feature's headline
-        action (docs/F-PREDRAIN.md F4) — surface it with the load name, the booked
-        slot times and the grid import the trade cost. Emitted only when the set of
-        night-booked (load, slot-start) pairs CHANGES vs the previous log (FIX-11):
-        the plan re-runs every 5 min, so an unchanged night booking would otherwise
-        spam an identical line every cycle.
+        A pre-drain "make room" run (pass 2) that lands OUTSIDE every PV
+        absorption window is the F-PREDRAIN feature's headline action
+        (docs/F-PREDRAIN.md F4) — surface it with the load name, the booked
+        slot times and the grid import the trade cost. Only continuous loads
+        can appear here: energy-limited loads are barred from zero-PV pass-2
+        slots by construction (F-GATE-PARITY daylight rule), and their allowed
+        pre-window DAYLIGHT bookings would be misread as "night" by this log's
+        strong-PV window test — the class skip below keeps the line honest.
+        Emitted only when the set of night-booked (load, slot-start) pairs
+        CHANGES vs the previous log (FIX-11): the plan re-runs every 5 min, so
+        an unchanged night booking would otherwise spam an identical line
+        every cycle.
         """
         ends = result.pv_window_ends  # {iso date -> last strong-PV hour}
         if not result.load_plans:
@@ -993,7 +998,9 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         pairs: set[tuple[str, str]] = set()
         for load_plan, load in zip(result.load_plans, config.loads, strict=True):
             if load.energy_limited:
-                continue  # pre-drain is continuous-loads only (F-PREDRAIN L5)
+                # Cannot book night slots (F-GATE-PARITY daylight rule); their
+                # pre-window daylight bookings are not night pre-drains.
+                continue
             night = [
                 inputs.slots[j]
                 for start, count, pass_no, _wh in load_plan.allocations

--- a/custom_components/battery_manager/core/optimize.py
+++ b/custom_components/battery_manager/core/optimize.py
@@ -452,6 +452,14 @@ def allocate_loads(
     creation order, F-LOAD-PRIORITY). Every assignment is validated by
     re-simulation over the FULL horizon: no additional grid import (Z2) and the
     SOC buffer floor holds (Z3).
+
+    GATE PARITY (F-GATE-PARITY, operator decision 2026-07-17): both load
+    classes face the IDENTICAL gate set — one Z2' trade invariant, c1-rt/c2
+    opportunity gates and the Z4 stress floor — so the priority order alone
+    decides who gets contested energy ("lieber den Fossibot laden, als den
+    Luftentfeuchter betreiben, wenn die Wahl besteht"). The single remaining
+    class rule: energy-limited loads never book zero-PV (night) slots in
+    pass 2 — nights stay reserved for continuous loads.
     """
     n = len(inputs.slots)
     states = {s.load_id: s for s in inputs.load_states}
@@ -508,21 +516,20 @@ def allocate_loads(
     windows = pv_windows(inputs, control.strong_pv_cutoff_w, control.pv_window_end_hour)
     current = base_trajectory
 
-    def import_ok(load, traj: Trajectory, current_import: float) -> bool:
-        """Z2' import gate. Energy-limited loads keep the strict no-extra-import
-        rule (L5 keeps them out of the pre-drain machinery), but anchored at the
-        CURRENTLY ACCEPTED series rather than the no-loads base (FIX-2): a booking
-        must not ADD import over what is already accepted, so once a continuous
-        load has traded some import an energy-limited candidate on pure surplus is
-        no longer starved by that inherited delta. Continuous loads use the
-        cumulative trade invariant against the no-loads base: a small import is
-        allowed only in exchange for rescued export at `import_trade_ratio`, plus
-        1 Wh of slack ONLY when a positive ratio is configured (FIX-6) so a lone
-        standby artifact never vetoes a traded run (L1). At ratio 0.0 there is no
-        slack, so the continuous gate is `trial import <= base + _EPS` exactly as
-        v0.7.19 — night pre-drains still need a positive ratio to book."""
-        if load.energy_limited:
-            return traj.total_import_wh <= current_import + _EPS
+    def import_ok(traj: Trajectory) -> bool:
+        """Z2' import gate — ONE cumulative trade invariant for ALL load
+        classes (F-GATE-PARITY R1). A small import is allowed only in exchange
+        for rescued export at `import_trade_ratio`, plus 1 Wh of slack ONLY
+        when a positive ratio is configured (FIX-6) so a lone standby artifact
+        never vetoes a traded run (L1). At ratio 0.0 there is no slack, so the
+        gate is `trial import <= base + _EPS` exactly as v0.7.19 — night
+        pre-drains still need a positive ratio to book. The former
+        energy-limited strict branch (anchored at the currently accepted
+        series, FIX-2) is superseded: its anchor existed only to shield
+        energy-limited candidates from inheriting continuous trade deltas,
+        and under one shared base-anchored budget there is no per-class
+        anchor left to inherit — class asymmetry here silently overrode the
+        operator's load priority order."""
         allowed = ratio * (base_export - traj.total_export_wh) + (
             1.0 if ratio > 0.0 else 0.0
         )
@@ -589,7 +596,7 @@ def allocate_loads(
                     continue
                 # Hard conditions via full re-simulation (Z2'/Z3).
                 traj = simulate(config, inputs, threshold, extra_ac_wh=tuple(trial))
-                if not import_ok(load, traj, current.total_import_wh):
+                if not import_ok(traj):
                     continue
                 if _degrades_min_soc(traj, current, buffer_floor):
                     continue
@@ -630,14 +637,19 @@ def allocate_loads(
     #   Z3  buffer floor   — nominal min SOC not degraded below soc_min+buffer,
     #   Z4  lower buffer   — even a pessimistic (alpha) PV run keeps the inverter
     #                        reserve above its floor across the bet's recovery
-    #                        window [i, recovery] (continuous loads only, F3 v2),
+    #                        window [i, recovery] (F3 v2),
     #   (c) opportunity    — (c1) the nominal drain is refilled from lost export,
     #                        OR (c2) inside the day's PV window an optimistic
     #                        (beta) run would be (upper-buffer insurance, F4).
-    # Energy-limited loads stay on the legacy nominal-only path (a1/c1) and never
-    # night-charge from the house battery (L5). Iterated latest-first (L4); slots
-    # after the last export can never satisfy the gate, so they are skipped, as
-    # is the whole pass on an export-free horizon.
+    # All gates apply to ALL load classes (F-GATE-PARITY: the former
+    # energy-limited c1-only carve-out let a lower-priority continuous load take
+    # bet energy a higher-priority powerstation was forbidden, silently
+    # overriding the operator's priority order). The one remaining class rule is
+    # the DAYLIGHT restriction: energy-limited loads never book zero-PV (night)
+    # slots — nights stay reserved for continuous loads (operator refinement 2,
+    # 2026-07-17). Iterated latest-first (L4); slots after the last export can
+    # never satisfy the gate, so they are skipped, as is the whole pass on an
+    # export-free horizon.
     if current.total_export_wh > _EPS:
         # Optimistic opportunity baseline for the CURRENTLY accepted series —
         # whole-horizon, kept in step with `current` and refreshed only on
@@ -676,6 +688,14 @@ def allocate_loads(
                 state = states.get(load.load_id, SurplusLoadState(load_id=load.load_id))
                 if not state.available or schedules[load.load_id][i]:
                     continue
+                # Daylight rule (F-GATE-PARITY refinement 2): energy-limited
+                # loads never open a bet in a zero-PV (night) slot. Deliberately
+                # `pv_wh > 0` and NOT `in_window` — pre-window daylight
+                # pre-charges before a short peak stay allowed (they were a
+                # pinned capability before parity, and forbidding them would
+                # re-introduce a class asymmetry in daylight).
+                if load.energy_limited and slot.pv_wh <= 0.0:
+                    continue
                 power_w = state.planning_power_w(load)
                 rem = remaining[load.load_id]
                 # Largest-first quantised search (F-SUBHOUR): a sub-hour
@@ -697,9 +717,17 @@ def allocate_loads(
                     )
                     if any(schedules[load.load_id][j] for j, _ in covered):
                         continue
+                    if load.energy_limited and any(
+                        inputs.slots[j].pv_wh <= 0.0 for j, _ in covered
+                    ):
+                        # Daylight rule, spill guard: a min-runtime commitment
+                        # near the day's edge must not spill into night slots;
+                        # shorter quantised candidates (incl. the gate-stop
+                        # final quantum) still get their chance below.
+                        continue
                     trial_tuple = tuple(trial)
                     traj = simulate(config, inputs, threshold, extra_ac_wh=trial_tuple)
-                    if not import_ok(load, traj, current.total_import_wh):  # Z2'
+                    if not import_ok(traj):  # Z2'
                         continue
                     if _degrades_min_soc(traj, current, buffer_floor):  # Z3
                         continue
@@ -718,73 +746,71 @@ def allocate_loads(
                     need_c2 = (1.0 - load.battery_tolerance) * power_wh
                     trial_beta = None
                     via_beta = False  # which gate accepted -> reason string (R13)
-                    if load.energy_limited:
-                        # Legacy nominal refill gate only (no two-buffer machinery).
-                        if export_drop + _EPS < need:
-                            continue
-                    else:
-                        # (c1) nominal refill OR (c2) optimistic in-window insurance.
-                        accept = export_drop + _EPS >= need
-                        if not accept and c2_active and in_window(i):
-                            trial_beta = simulate(
+                    # (c1) nominal refill OR (c2) optimistic in-window insurance
+                    # — identical for BOTH load classes (F-GATE-PARITY R2; the
+                    # former energy-limited c1-only path is superseded).
+                    accept = export_drop + _EPS >= need
+                    if not accept and c2_active and in_window(i):
+                        trial_beta = simulate(
+                            config,
+                            inputs,
+                            threshold,
+                            extra_ac_wh=trial_tuple,
+                            pv_scale=optimism_vec,
+                        )
+                        drop_beta = (
+                            current_beta.total_export_wh - trial_beta.total_export_wh
+                        )
+                        # c2 judges an optimistic direct-PV absorption, not
+                        # a battery detour: the unscaled need applies.
+                        accept = drop_beta + _EPS >= need_c2
+                        via_beta = accept
+                    if not accept:
+                        continue
+                    # Z4 windowed lower-buffer stress gate (§3.3 v2): stress
+                    # PV only across the bet window [i, recovery] and take
+                    # the windowed min. Reject iff that stressed reserve
+                    # both breaks the inverter floor AND is worse than the same
+                    # windowed min on the currently accepted series — a dip the
+                    # baseline already contains does not veto the bet.
+                    # Per-slot stress (F-QUANTILE-BANDS R4): empirical P10
+                    # where a band exists, alpha elsewhere — Z4 protection
+                    # now varies with the weather-class history. Since
+                    # F-GATE-PARITY the stress gate also binds energy-limited
+                    # bets: whoever takes bet energy respects the floors.
+                    if z4_active:
+                        # Extend the stress window past `recovery` when this
+                        # candidate's run spills beyond it (a min-runtime
+                        # commitment near the window end lands in later slots):
+                        # the spill drains the reserve too, so it must be
+                        # stressed and included in the windowed min (FIX-7).
+                        hi = max(recovery, covered[-1][0])
+                        scale_vec = [
+                            stress_vec[j] if i <= j <= hi else 1.0 for j in range(n)
+                        ]
+                        trial_stress = simulate(
+                            config,
+                            inputs,
+                            threshold,
+                            extra_ac_wh=trial_tuple,
+                            pv_scale=scale_vec,
+                        )
+                        trial_wmin = _windowed_min_soc(trial_stress, i, hi)
+                        key = (i, hi)
+                        if key not in stress_base:
+                            base_stress = simulate(
                                 config,
                                 inputs,
                                 threshold,
-                                extra_ac_wh=trial_tuple,
-                                pv_scale=optimism_vec,
-                            )
-                            drop_beta = (
-                                current_beta.total_export_wh
-                                - trial_beta.total_export_wh
-                            )
-                            # c2 judges an optimistic direct-PV absorption, not
-                            # a battery detour: the unscaled need applies.
-                            accept = drop_beta + _EPS >= need_c2
-                            via_beta = accept
-                        if not accept:
-                            continue
-                        # Z4 windowed lower-buffer stress gate (§3.3 v2): stress
-                        # PV only across the bet window [i, recovery] and take
-                        # the windowed min. Reject iff that stressed reserve
-                        # both breaks the inverter floor AND is worse than the same
-                        # windowed min on the currently accepted series — a dip the
-                        # baseline already contains does not veto the bet.
-                        # Per-slot stress (F-QUANTILE-BANDS R4): empirical P10
-                        # where a band exists, alpha elsewhere — Z4 protection
-                        # now varies with the weather-class history.
-                        if z4_active:
-                            # Extend the stress window past `recovery` when this
-                            # candidate's run spills beyond it (a min-runtime
-                            # commitment near the window end lands in later slots):
-                            # the spill drains the reserve too, so it must be
-                            # stressed and included in the windowed min (FIX-7).
-                            hi = max(recovery, covered[-1][0])
-                            scale_vec = [
-                                stress_vec[j] if i <= j <= hi else 1.0 for j in range(n)
-                            ]
-                            trial_stress = simulate(
-                                config,
-                                inputs,
-                                threshold,
-                                extra_ac_wh=trial_tuple,
+                                extra_ac_wh=tuple(extra),
                                 pv_scale=scale_vec,
                             )
-                            trial_wmin = _windowed_min_soc(trial_stress, i, hi)
-                            key = (i, hi)
-                            if key not in stress_base:
-                                base_stress = simulate(
-                                    config,
-                                    inputs,
-                                    threshold,
-                                    extra_ac_wh=tuple(extra),
-                                    pv_scale=scale_vec,
-                                )
-                                stress_base[key] = _windowed_min_soc(base_stress, i, hi)
-                            if (
-                                trial_wmin < stress_floor_by_slot[i] - _EPS
-                                and trial_wmin < stress_base[key] - _EPS
-                            ):
-                                continue
+                            stress_base[key] = _windowed_min_soc(base_stress, i, hi)
+                        if (
+                            trial_wmin < stress_floor_by_slot[i] - _EPS
+                            and trial_wmin < stress_base[key] - _EPS
+                        ):
+                            continue
                     extra = trial
                     current = traj
                     stress_base.clear()  # `extra` changed -> windowed baselines stale
@@ -979,14 +1005,15 @@ def plan(config: SystemConfig, inputs: PlanInputs) -> PlanResult:
     """One complete planning run — single consistent trajectory out (P2).
 
     The `stressed_min_soc_percent` diagnostic (§3.5, v2) reports the WINDOWED
-    lower-buffer reserve that the Z4 gate actually protects: the earliest pass-2
-    slot booked for a CONTINUOUS load is treated as the deepest bet, and the
-    diagnostic is the stressed windowed min SOC over that bet's recovery window
-    [i0, recovery] under the FINAL accepted series — stressed with the same
-    per-slot vector as the gate (P10 bands where present, alpha elsewhere;
-    F-QUANTILE-BANDS R5). It is None when no slot is stressed (alpha == 1.0
-    and no P10 evidence) or when no continuous load has a pass-2 booking
-    (nothing was pre-drained, so there is no reserve bet to report).
+    lower-buffer reserve that the Z4 gate actually protects: the earliest
+    pass-2 slot booked for ANY load is treated as the deepest bet
+    (F-GATE-PARITY GP-R4 — the stress gate binds energy-limited bets too),
+    and the diagnostic is the stressed windowed min SOC over that bet's
+    recovery window [i0, recovery] under the FINAL accepted series — stressed
+    with the same per-slot vector as the gate (P10 bands where present, alpha
+    elsewhere; F-QUANTILE-BANDS R5). It is None when no slot is stressed
+    (alpha == 1.0 and no P10 evidence) or when no load at all has a pass-2
+    booking (nothing was bet, so there is no reserve to report).
     """
     control = config.control
     threshold, base_traj = search_threshold(config, inputs)
@@ -1032,17 +1059,14 @@ def plan(config: SystemConfig, inputs: PlanInputs) -> PlanResult:
     )
     if any(s < 1.0 - _EPS for s in stress_vec) and alloc_traj.flows:
         # Windowed stressed reserve of the deepest bet: the earliest pass-2 slot
-        # booked for a continuous (non-energy-limited) load, evaluated over its
-        # recovery window under the final series (§3.5 v2). None when nothing was
-        # pre-drained for a continuous load.
+        # booked for ANY load, evaluated over its recovery window under the
+        # final series (§3.5 v2). Since F-GATE-PARITY the Z4 stress gate binds
+        # energy-limited bets too, so their bookings belong in the diagnostic —
+        # what the sensor reports is what the gate protected. None when no
+        # pass-2 booking exists at all.
         n = len(inputs.slots)
-        cont_ids = {ld.load_id for ld in config.loads if not ld.energy_limited}
         booked = [
-            alloc[0]
-            for lp in load_plans
-            if lp.load_id in cont_ids
-            for alloc in lp.allocations
-            if alloc[2] == 2
+            alloc[0] for lp in load_plans for alloc in lp.allocations if alloc[2] == 2
         ]
         if booked:
             i0 = min(booked)

--- a/custom_components/battery_manager/manifest.json
+++ b/custom_components/battery_manager/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danielr0815/battery-manager-ha/issues",
   "requirements": [],
-  "version": "0.12.0"
+  "version": "0.13.0"
 }

--- a/docs/ALGORITHM.md
+++ b/docs/ALGORITHM.md
@@ -115,6 +115,12 @@ candidates).
   is automatically discarded by (a) (the battery would breach the
   inverter minimum → import); the useful scenario "short
   sun window, high SOC" is automatically allowed.
+  **v0.13.0 (F-GATE-PARITY):** both load classes face the IDENTICAL pass-2
+  gate set (one Z2' trade invariant, c1-rt, c2-beta insurance, Z4 stress),
+  so priority alone decides contested bet energy — the former
+  energy-limited c1-only/strict-import carve-out silently overrode the
+  priority order. Single remaining class rule: energy-limited loads never
+  book zero-PV (night) slots.
 - **Merge principle (operator insight, 2026-07-04):** All gate conditions
   are **difference comparisons** of two complete trajectories. As soon as
   both variants (with/without the load hour) reach the max SOC, they are

--- a/docs/F-GATE-PARITY.md
+++ b/docs/F-GATE-PARITY.md
@@ -1,0 +1,123 @@
+# F-GATE-PARITY — one gate set for both load classes, priority decides
+
+Status: **binding spec**, implemented in v0.13.0. Operator decision 2026-07-17:
+
+> „Es ist ein Spezifikationsfehler, dass B Energie nicht verwenden darf aber
+> der Luftentfeuchter schon. Es soll immer die Priorität eingehalten werden…
+> lieber den Fossibot laden, als den Luftentfeuchter betreiben, wenn die Wahl
+> besteht."
+
+## 1. Diagnosis (live incident, 2026-07-17)
+
+The Fossibot F2400-B (priority 1) was externally drained to its 20 % discharge
+floor by midday while the dehumidifier (priority 3) ran 13:00–15:15 on
+battery-share "make-room" bets. BM had charged B the moment direct surplus
+existed (12:50, ~700 W — priority worked in pass 1), but once PV faded, the
+CLASS rules — not priority — decided who could keep taking energy: continuous
+loads had the Z2' import-trade slack, the c2 beta insurance and the Z4-stressed
+battery-share machinery; energy-limited loads were confined to a strict
+no-extra-import gate and a c1-only pass-2 path. A lower-priority load could
+book bet energy a higher-priority load was forbidden. That class asymmetry is
+the spec error this feature removes.
+
+## 2. Operator refinements (AskUserQuestion, 2026-07-17)
+
+1. **Full import-trade parity.** Energy-limited loads use the SAME Z2'
+   cumulative trade invariant (`import − base_import ≤ ratio · rescued_export
+   + 1 Wh slack iff ratio > 0`, anchored at the no-loads base) as continuous
+   loads. The former strict current-anchored branch (F-PREDRAIN FIX-2) is
+   superseded: its anchor only existed to shield energy-limited candidates
+   from inheriting continuous trade deltas — under one shared budget there is
+   no per-class anchor to inherit.
+2. **Nights stay continuous-only.** Energy-limited loads never book zero-PV
+   pass-2 slots. Chosen predicate: **daylight** (`slot.pv_wh > 0`), NOT
+   `in_window` — the stricter predicate would also bar pre-window daylight
+   pre-charges before a short peak (a capability pinned by tests and golden
+   before parity), re-introducing a daylight class asymmetry. Revert point if
+   ever wanted stricter: the two predicate checks in `allocate_loads` pass 2.
+
+## 3. Requirements
+
+- **GP-R1** One `import_ok` for all loads (core/optimize.py, Z2' trade
+  invariant). No class branch.
+- **GP-R2** Pass-2 opportunity gates (c1-rt OR c2-beta-in-window) and the Z4
+  windowed stress gate apply identically to both classes. Energy-limited
+  candidates are additionally skipped when the candidate slot has
+  `pv_wh ≤ 0` or the commitment would spill into a `pv_wh ≤ 0` slot
+  (daylight rule; shorter quanta still get their chance).
+- **GP-R3** Priority semantics (unchanged code, now load-bearing): pass 1 is
+  load-outer in config order (strict global priority); pass 2 is slot-outer
+  latest-first with loads inner in config order — within a contested slot the
+  higher-priority load consumes budget first.
+- **GP-R4** Diagnostics: `stressed_min_soc_percent` covers the earliest
+  pass-2 booking of ANY load (the `cont_ids` filter is gone). The
+  night-pre-drain INFO log keeps its energy-limited skip as a redundant
+  guard: the class cannot book night slots, and its legitimate pre-window
+  daylight bookings must not be misread as night pre-drains by the log's
+  strong-PV window test.
+
+## 4. Test contract (tests/core/test_optimize.py)
+
+- `test_gate_parity_contested_bet_goes_to_priority_one` — a depth-capped bet
+  slot (room for exactly one booking above the inverter cutoff) goes to
+  whichever load is first in config order; swapping the order swaps the
+  winner.
+- `test_gate_parity_z4_stress_binds_energy_limited_bets` — Z4 caps an
+  energy-limited bet's depth (α=0.5 rejects the full quantum in the
+  cutoff↔ramped-floor gap; α=1.0 books it).
+- `test_gate_parity_daylight_rule_blocks_fb_night_predrain` — maximum
+  temptation, T1-shaped horizon: the fossibot never books a zero-PV slot
+  while the same horizon's night pre-drain IS booked by a continuous load.
+- `test_gate_parity_c2_beta_books_energy_limited_in_window` — T12 parity:
+  beta opens extra in-window slots for the fossibot, reason string
+  "in-window insurance", trade invariant holds.
+- `test_gate_parity_shared_trade_budget_across_classes` (rewrites FIX-2) —
+  shared budget: fb books 2250 Wh (was 1800 under the strict gate); the b1
+  cumulative invariant and b2 attribution bound keep holding.
+- Strengthened: T3 (never night — now via the daylight rule; every ON slot
+  additionally asserts `pv_wh > 0`). Adapted with dawn shoulder light
+  (`_twilight`, 5 Wh) so their pre-window intent survives the daylight rule:
+  `test_pass2_preemptive_charging_when_sun_window_too_short`,
+  `test_pass2_places_preemptive_hours_latest_first`,
+  `test_pass2_residual_books_latest_of_two_feasible_slots`.
+
+## 5. Golden classification (v0.13.0 regeneration)
+
+- All no-load scenarios, `s3_loads_night`, `s3_low_soc_5am`, `s4_midday_full`
+  and the whole `golden_night_predrain.json`: **bit-identical**. (In the
+  night-predrain scene the fossibot's small residual need is met by pass 1,
+  so no budget contest arises and the dehumidifier's night pre-drain is
+  untouched.)
+- `short_peak_preempt`: **expected delta** — f1 loses its three pre-window
+  pass-2 hours (1800 → 900 Wh, lost surplus 2.31 → 3.40 kWh, import
+  unchanged 0.0, no slot outside 11–14). The synthetic two-window PV model
+  has EXACTLY 0 Wh before 11:00, so the pre-window hours are night by the
+  daylight rule. Real hourly forecasts carry morning light — live, the
+  pre-window pre-charge capability persists (the adapted tests model this
+  with `_twilight`).
+
+## 6. Supersedes
+
+- F-PREDRAIN.md L5 ("pre-drain applies to continuous loads only", "NEVER
+  night-charged" as a class rule) and §3.2 FIX-2 (strict current-anchored
+  energy-limited gate).
+- F-NIGHT-RESCUE.md non-goal "the energy-limited L5 restrictions stay
+  (strict import, no β/c2)" and the R8 "continuous-load pre-drain bets"
+  scoping (Z4's ramped floor now binds energy-limited bets too).
+- F-RESIDUAL-TOPUP.md non-goal restating the L5 carve-out ("no α-stress,
+  no β-insurance, strict import gate").
+- F-PREDRAIN.md §3.2 / §3.4 class-scoped gate definitions ("for candidates
+  of continuous loads").
+- The stale optimize.py L5 comments (removed with this feature).
+- L5 survives ONLY as: energy-limited loads never book zero-PV (night)
+  slots. Everything else is parity + priority.
+
+## 7. Risks accepted by the operator
+
+1. The dehumidifier's night pre-drain can shrink on days where a hungry
+   fossibot consumes the trade/c2 budget first — intended (priority).
+2. `stressed_min_soc_percent` may jump between releases (now covers
+   energy-limited bets).
+3. Fossibot charging may now cause small traded grid import (bounded by the
+   shared `import_trade_ratio` budget, live 0.1).
+4. Dawn-shoulder slots (minimal PV) count as daylight — deliberate.

--- a/docs/F-NIGHT-RESCUE.md
+++ b/docs/F-NIGHT-RESCUE.md
@@ -106,7 +106,9 @@ removal. All planner gates keep applying.
 
 ### F3 — crossover buffer ramp (D3)
 
-- **R8** For the Z4 stress floor ONLY (continuous-load pre-drain bets), the
+- **R8** For the Z4 stress floor ONLY (pre-drain bets; ~~continuous-load~~
+  class scoping superseded v0.13.0, docs/F-GATE-PARITY.md — Z4 binds
+  energy-limited bets too), the
   BUFFER component ramps with the remaining stressed deficit: for a candidate
   slot `i`, `buffer_eff(i) = min(soc_buffer_percent,
   100 · stressed_deficit_wh(i) / battery.capacity_wh)` where
@@ -155,9 +157,13 @@ removal. All planner gates keep applying.
 No executor changes. No new config keys (rt derives from existing
 efficiencies; ramp uses existing buffer/inverter_min; merge bound is
 structural). No change to pass ordering, saturation/gate-topup, quantile
-ingestion. The energy-limited L5 restrictions stay (strict import, no
+ingestion. ~~The energy-limited L5 restrictions stay (strict import, no
 β/c2) — but they GET the rt-honest c1 (R2 covers both branches) so fossibot
-pre-dawn top-ups before a clipping day become feasible too.
+pre-dawn top-ups before a clipping day become feasible too.~~
+**Superseded (v0.13.0, docs/F-GATE-PARITY.md):** full gate parity for
+energy-limited loads (shared Z2' trade, c2, Z4); only the zero-PV night
+exclusion remains, so the pre-dawn top-up this line anticipated is now
+explicitly barred while all DAYLIGHT bets are open to them.
 
 ## Verify
 

--- a/docs/F-PREDRAIN.md
+++ b/docs/F-PREDRAIN.md
@@ -38,9 +38,12 @@ integration, 15-min buckets) are ignored.
   shrink toward the forecast solar onset.
 - **L4** "As late as possible" stands: preemptive runs as late as the
   constraints allow, just early enough that nothing must be exported.
-- **L5** Energy-limited loads (Fossibot powerstations) are NEVER night-charged
+- **L5** ~~Energy-limited loads (Fossibot powerstations) are NEVER night-charged
   from the house battery (operator decisions 2026-07-04/05). Pre-drain applies
-  to continuous loads only.
+  to continuous loads only.~~ **Superseded (v0.13.0, docs/F-GATE-PARITY.md):**
+  both classes now share the full pass-2 gate set (Z2' trade, c1-rt, c2, Z4)
+  and priority decides contested energy; L5 survives only as "energy-limited
+  loads never book zero-PV (night) slots".
 - **L6** There are TWO buffers. The UPPER buffer (absorption headroom near max
   SOC) must be preserved while significant solar power is still expected for
   this specific installation; it may shrink from the moment the sun moves
@@ -112,9 +115,10 @@ integration, 15-min buckets) are ignored.
 
 ### 3.2 F2 — Import trade rule Z2' (WP2)
 
-For candidates of **continuous** (non-energy-limited) loads, in BOTH passes,
-replace the absolute Z2 check with the cumulative invariant against the
-no-loads base trajectory:
+For candidates of ~~**continuous** (non-energy-limited)~~ **ALL** loads
+(class scoping superseded v0.13.0, docs/F-GATE-PARITY.md GP-R1), in BOTH
+passes, replace the absolute Z2 check with the cumulative invariant against
+the no-loads base trajectory:
 
 ```
 (trial.total_import_wh - base_import_wh)
@@ -131,15 +135,13 @@ no-loads base trajectory:
   today's behavior exactly" guarantee; resolved here.)
 - Recommended live value 0.10 is applied as the coordinator absent-key fallback
   and config-flow default (WP3), NOT as the dataclass default.
-- Energy-limited loads keep a STRICT no-extra-import comparison (L5), but anchored
-  at the CURRENTLY ACCEPTED series' import, not the no-loads base (FIX-2):
-  `trial.total_import_wh <= current.total_import_wh + EPS`. An energy-limited
-  booking must never add import (it stays out of the pre-drain trade machinery),
-  but once a continuous load has already traded a little import, anchoring at the
-  base would starve every LATER energy-limited candidate on pure surplus (it
-  inherits the delta it did not cause). Anchoring per-candidate at `current`
-  preserves L5 (the fossibot adds no import) while letting it still fill on
-  genuine surplus. `current`'s import is threaded into the gate in both passes.
+- ~~Energy-limited loads keep a STRICT no-extra-import comparison (L5), but
+  anchored at the CURRENTLY ACCEPTED series' import, not the no-loads base
+  (FIX-2).~~ **Superseded (v0.13.0, docs/F-GATE-PARITY.md GP-R1):** one Z2'
+  trade invariant for ALL load classes, anchored at the no-loads base. The
+  FIX-2 current-anchor only existed to shield energy-limited candidates from
+  inheriting continuous trade deltas; under one shared budget there is no
+  per-class anchor left to inherit.
 
 ### 3.3 F3 — Lower buffer: pessimistic stress gate Z4 (WP2; REVISED v2)
 
@@ -194,7 +196,9 @@ kWh, and (c) keep `import_trade_used_wh <= 0.10 x rescued export + 1 Wh`.
   `pv_wh / duration >= strong_pv_cutoff_w`. If `pv_window_end_hour` is set
   (site override), `last` is capped at the last slot starting before that local
   hour. "Sun behind the house" = after `last`.
-- **Gate (c) generalized** for pass-2 candidates of continuous loads. Accept if
+- **Gate (c) generalized** for pass-2 candidates of ~~continuous~~ ALL loads
+  (class scoping superseded v0.13.0, docs/F-GATE-PARITY.md GP-R2;
+  energy-limited candidates are additionally daylight-restricted). Accept if
   EITHER:
   - (c1) nominal `export_drop >= (1 - battery_tolerance) * power_wh` (existing), OR
   - (c2) the candidate slot lies INSIDE its day's PV window AND, in the
@@ -266,6 +270,8 @@ Core (fast, `.venv/Scripts/python.exe -m pytest tests/core/`):
 - T2 cumulative invariant: over a multi-candidate scenario, final
   `import - base <= 0.1 * (base_export - export)`.
 - T3 energy-limited load never gets a no-surplus slot even with ratio > 0.
+  (Since v0.13.0 / F-GATE-PARITY: never a ZERO-PV slot — in-daylight
+  no-surplus slots are full-parity bet candidates.)
 - T4 alpha stress: deep 22:00 multi-hour run rejected, same-energy pre-dawn run
   accepted; alpha=1.0 disables; floor is inverter_min_soc + buffer.
 - T5 latest-first tie: of two equally feasible night slots the later books.

--- a/docs/F-RESIDUAL-TOPUP.md
+++ b/docs/F-RESIDUAL-TOPUP.md
@@ -54,9 +54,11 @@ cached values with fresh timestamps).
 **Non-goals.** No new config. No change to pass-1's ascending slot order
 (each direct-surplus hour is use-it-or-lose-it *in place*; see open decision
 O1 in §8 for within-window micro-ordering). No change to Z2'/Z3/Z4 gate
-formulas, to the c1/c2 opportunity gates, or to L5 (energy-limited loads stay
+formulas, to the c1/c2 opportunity gates, or to L5 ~~(energy-limited loads stay
 out of the two-buffer pre-drain machinery: no α-stress, no β-insurance, strict
-import gate). No planner modelling of `min_off` spacing between two disjoint
+import gate)~~ — **the parenthesised L5 semantics are superseded (v0.13.0,
+docs/F-GATE-PARITY.md): full gate parity; only the zero-PV night exclusion
+remains**. No planner modelling of `min_off` spacing between two disjoint
 sub-hour activations (pre-existing F-SUBHOUR limitation, unchanged — see §6
 known limitations). No simulator changes.
 

--- a/docs/LOAD_CONTROL.md
+++ b/docs/LOAD_CONTROL.md
@@ -142,6 +142,15 @@ SOC (ground truth) anyway, not integrated over the power.
   minimum-runtime-honest evaluation (ALGORITHM.md D-A4 v3). The trigger was the
   night-charge incident of 05.07 (degenerate-slot-0 bug: three starts each at
   minute :59, really ~250 Wh per "5 Wh plan").
+- **F-GATE-PARITY (2026-07-17, v0.13.0): priority always wins over load
+  class.** The former class asymmetry — continuous loads could take
+  make-room/battery-share bet energy (Z2' trade slack, c2, Z4) that
+  energy-limited powerstations were denied — let a lower-priority
+  dehumidifier out-book a higher-priority Fossibot ("lieber den Fossibot
+  laden, als den Luftentfeuchter betreiben, wenn die Wahl besteht"). Both
+  classes now face the identical pass-2 gate set; the single remaining class
+  rule is that energy-limited loads never book zero-PV (night) slots. See
+  docs/F-GATE-PARITY.md.
 - Alongside this, the coordinator persists the switch dwell across restarts
   (the loss was a contributing cause). The power EMA is deliberately NOT
   persisted, and on feedback gaps is only served while the load is really

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -193,6 +193,11 @@ grid import/export for the forecast period.
 
 - **D1 Priority:** Loads may run **in parallel** when the surplus is enough for
   several; the priority order only decides in case of scarcity.
+  **Extended 2026-07-17 (F-GATE-PARITY):** priority decides ALL contested
+  energy, including pass-2 make-room/battery-share bets — load-class rules
+  must never override it ("lieber den Fossibot laden, als den
+  Luftentfeuchter betreiben, wenn die Wahl besteht"). Energy-limited loads
+  keep exactly one class rule: no zero-PV (night) slots.
 - **D2 Fossibots:** Charge only, throttled to **300 W**. The energy supplies
   directly connected loads (e.g. PC) — no feed-back into the house grid. The
   **actual charging power should be read from the feedback of the HA entities**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "battery-manager-ha"
-version = "0.12.0"
+version = "0.13.0"
 description = "Solar-battery optimizer for Home Assistant: SOC forecast, discharge-threshold planning, surplus-load and grid-support control."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/core/golden_topology.json
+++ b/tests/core/golden_topology.json
@@ -874,13 +874,13 @@
  "short_peak_preempt": {
   "dc24_now": false,
   "dc48_now": false,
-  "export_kwh": 2.305269,
+  "export_kwh": 3.399698,
   "hours_to_max": 17,
   "import_kwh": 0.0,
   "inverter_on": true,
   "loads": {
    "f1": [
-    1800.0,
+    900.0,
     [
      false,
      false,
@@ -894,9 +894,9 @@
      false,
      false,
      false,
-     true,
-     true,
-     true,
+     false,
+     false,
+     false,
      true,
      true,
      true,
@@ -914,7 +914,7 @@
    ]
   },
   "max_soc": 95.0,
-  "min_soc": 22.0944,
+  "min_soc": 41.6278,
   "soc_curve": [
    87.043,
    84.086,
@@ -928,10 +928,10 @@
    64.552,
    59.967,
    55.383,
-   44.286,
-   33.19,
-   22.094,
-   61.598,
+   50.798,
+   46.213,
+   41.628,
+   81.132,
    95.0,
    95.0,
    90.415,

--- a/tests/core/test_optimize.py
+++ b/tests/core/test_optimize.py
@@ -386,10 +386,25 @@ def test_dc48_activate_soc_configurable():
     assert any(dc48_wide)
 
 
+def _twilight(day: datetime, *hours: int) -> dict[datetime, float]:
+    """A few Wh of dawn shoulder light for the given hours (F-GATE-PARITY).
+
+    The synthetic two-window PV model leaves pre-window hours at EXACTLY
+    0 Wh, which the daylight rule reads as night. Real hourly forecasts
+    never do that — any morning hour carries a little light — so the
+    short-peak scenarios model it explicitly: 5 Wh per hour is far below
+    the 200 W strong-PV cutoff (the window stays short) and energetically
+    negligible, but marks the hours as daylight. The uncovered rest of the
+    day keeps its two-window shape via the residual spread."""
+    return {day.replace(hour=h, minute=0): 5.0 for h in hours}
+
+
 def test_pass2_preemptive_charging_when_sun_window_too_short():
     """Short, strong production peak: a powerstation cannot saturate within
     the window, so pass 2 pre-charges it from the battery — provably refilled
-    from otherwise-lost surplus, without any grid import."""
+    from otherwise-lost surplus, without any grid import. Since F-GATE-PARITY
+    the pre-charge may only sit in DAYLIGHT hours (dawn shoulder light before
+    the window); zero-PV night hours are barred for energy-limited loads."""
     from core.model import PVParams
 
     short_peak = PVParams(
@@ -403,7 +418,15 @@ def test_pass2_preemptive_charging_when_sun_window_too_short():
     now = datetime(2026, 7, 5, 5, 0)
     states = (SurplusLoadState(load_id="fossibot_1", soc_percent=0.0),)
     # Single-day horizon: only 3 window hours exist — not enough for 2 kWh.
-    result, inputs = make_plan(config, now, 85.0, [8.0], load_states=states)
+    inputs = build_slots(
+        config,
+        now,
+        85.0,
+        [8.0],
+        load_states=states,
+        pv_hourly=_twilight(now, 8, 9, 10),
+    )
+    result = plan(config, inputs)
 
     window_hours = sum(
         1
@@ -413,6 +436,12 @@ def test_pass2_preemptive_charging_when_sun_window_too_short():
     preemptive_hours = sum(result.load_plans[0].schedule) - window_hours
     # More energy than the window alone could deliver, thanks to pass 2 ...
     assert preemptive_hours > 0
+    # ... never in a zero-PV (night) slot (F-GATE-PARITY daylight rule) ...
+    assert all(
+        inputs.slots[i].pv_wh > 0.0
+        for i, on in enumerate(result.load_plans[0].schedule)
+        if on
+    )
     # ... without increasing grid import over the no-load baseline (Z2) ...
     _, baseline = search_threshold(config, inputs)
     assert result.grid_import_kwh <= baseline.total_import_wh / 1000.0 + 1e-6
@@ -525,7 +554,17 @@ def test_pass2_places_preemptive_hours_latest_first():
     config = SystemConfig(pv=short_peak, loads=(FOSSIBOT_1,))
     now = datetime(2026, 7, 4, 20, 0)
     states = (SurplusLoadState(load_id="fossibot_1", soc_percent=0.0),)
-    result, inputs = make_plan(config, now, 90.0, [0.0, 8.0], load_states=states)
+    # Dawn shoulder light marks 8-10 as daylight (F-GATE-PARITY: an
+    # energy-limited pre-charge may not sit in zero-PV night slots).
+    inputs = build_slots(
+        config,
+        now,
+        90.0,
+        [0.0, 8.0],
+        load_states=states,
+        pv_hourly=_twilight(datetime(2026, 7, 5, 0, 0), 8, 9, 10),
+    )
+    result = plan(config, inputs)
 
     preemptive = [
         inputs.slots[i].hour_of_day
@@ -855,7 +894,17 @@ def test_pass2_residual_books_latest_of_two_feasible_slots():
 
     def pass2(soc):
         states = (SurplusLoadState(load_id="fossibot_1", soc_percent=soc),)
-        result, inputs = make_plan(config, now, 90.0, [0.0, 8.0], load_states=states)
+        # Dawn shoulder light: hours 9/10 must be daylight for the
+        # energy-limited overflow to be placeable at all (F-GATE-PARITY).
+        inputs = build_slots(
+            config,
+            now,
+            90.0,
+            [0.0, 8.0],
+            load_states=states,
+            pv_hourly=_twilight(datetime(2026, 7, 5, 0, 0), 8, 9, 10),
+        )
+        result = plan(config, inputs)
         lp = result.load_plans[0]
         hours = sorted(
             inputs.slots[s].hour_of_day for (s, _c, p, _wh) in lp.allocations if p == 2
@@ -1187,8 +1236,12 @@ def test_t2_cumulative_import_trade_invariant():
 
 
 def test_t3_energy_limited_never_night_charged_with_ratio():
-    """T3: even with a generous ratio, an energy-limited powerstation keeps the
-    strict no-extra-import rule and never night-charges (L5)."""
+    """T3: even with a generous ratio, full c2/Z4 machinery access and maximum
+    temptation, an energy-limited powerstation never night-charges. Since
+    F-GATE-PARITY the mechanism is the DAYLIGHT rule (zero-PV pass-2 slots are
+    barred for the class), no longer the strict import gate — the gates
+    themselves are shared with continuous loads and trading import for
+    in-daylight bookings is allowed."""
     now = datetime(2026, 7, 3, 21, 0)
     cfg = _predrain_config(ratio=0.5, alpha=0.5, beta=1.2, loads=(FOSSIBOT_B,))
     states = (SurplusLoadState(load_id="fossibot_b", soc_percent=0.0),)
@@ -1197,6 +1250,10 @@ def test_t3_energy_limited_never_night_charged_with_ratio():
         if on:
             assert daylight(inputs.slots[i]), (
                 f"fossibot night-charged at {inputs.slots[i].hour_of_day}:00"
+            )
+            # The binding predicate is PV, not the clock (F-GATE-PARITY).
+            assert inputs.slots[i].pv_wh > 0.0, (
+                f"fossibot booked a zero-PV slot at {inputs.slots[i].hour_of_day}:00"
             )
 
 
@@ -1500,25 +1557,19 @@ def test_fix1_appliance_windows_survive_predrain_booking():
     assert isinstance(result.appliance_windows["dishwasher"], bool)
 
 
-def test_fix2_energy_limited_books_surplus_after_continuous_trade():
-    """FIX-2: once a continuous load has traded a little import, the energy-limited
-    strict gate must anchor at the CURRENTLY ACCEPTED series, not the no-loads
-    base — otherwise the fossibot inherits the delta and is starved on a pure-
-    surplus slot it should still take. It must also never ADD import itself (L5).
+def test_gate_parity_shared_trade_budget_across_classes():
+    """F-GATE-PARITY R1 (rewrites FIX-2): both classes share ONE Z2' trade
+    invariant anchored at the no-loads base. The former energy-limited strict
+    gate (current-anchored, FIX-2) is superseded — under a single shared
+    budget there is no per-class anchor left to inherit, and the fossibot may
+    now trade import for daylight bookings exactly like the dehumidifier.
 
-    Scenario: modest day-1 then a strong day-2. The dehumidifier pre-drains and
-    trades ~10 Wh; the fossibot has a large remaining budget. With the fix it
-    charges every surplus slot it can (incl. pass-2 refills evaluated AFTER the
-    trade — one a 0.5 h residual quantum since F-RESIDUAL-TOPUP R1) and declines
-    the rest; the buggy gate booked strictly fewer slots.
-
-    Part (b) was RE-STATED in v0.11.0 (F-NIGHT-RESCUE knock-on): the rt-honest c1
-    changed the latest-first interleave, so the old counterfactual-final import
-    equality ("stripping the fossibot's energy reproduces the same import") no
-    longer holds — it was an emergent artifact of the pre-v0.11 booking pattern,
-    never a specced invariant. Attribution of a shared surplus pool is ill-defined;
-    part (b) now asserts the two BINDING trade-gate contracts instead. Documented
-    semantic change, not a weakened test."""
+    Scenario (unchanged from FIX-2): modest day-1 then a strong day-2. The
+    dehumidifier pre-drains and trades ~10 Wh; the fossibot has a large
+    remaining budget. Under parity the fossibot books MORE than the old
+    strict gate allowed (2250 Wh vs 1800 — parity can only add opportunities
+    here) while the cumulative trade invariant (b1) and the attribution
+    bound (b2) keep holding — they are the binding contracts."""
     now = datetime(2026, 7, 3, 21, 0)
     fb = SurplusLoad(
         load_id="fb",
@@ -1547,21 +1598,23 @@ def test_fix2_energy_limited_books_surplus_after_continuous_trade():
     load_plans, extra, traj = allocate_loads(cfg, inputs, threshold, base)
     fb_plan = next(p for p in load_plans if p.load_id == "fb")
 
-    # (a) A continuous trade fired AND the fossibot still books its full surplus
-    #     coverage (1800 Wh, incl. pass-2 refills — one a 0.5 h residual quantum,
-    #     F-RESIDUAL-TOPUP R1; re-baselined from 1950 by the F-NIGHT-RESCUE
-    #     rt-honest-c1 interleave shift, class-(x) knock-on). The buggy
-    #     base-anchored gate booked strictly fewer slots.
+    # (a) A continuous trade fired AND the fossibot books its parity coverage:
+    #     2250 Wh, 450 Wh MORE than the old strict gate's 1800 (pass-2 refills
+    #     incl. a 0.5 h residual quantum, F-RESIDUAL-TOPUP R1) — the shared
+    #     trade budget now finances fossibot bookings too.
     assert traj.total_import_wh - base.total_import_wh > 1e-6  # deh traded
     assert any(a[2] == 2 for a in fb_plan.allocations)  # a post-trade refill booked
-    assert abs(fb_plan.planned_energy_wh - 1800.0) < 1e-6
+    assert fb_plan.planned_energy_wh >= 1800.0 - 1e-6  # parity only ever adds
+    assert abs(fb_plan.planned_energy_wh - 2250.0) < 1e-6
+    # Daylight rule: every fossibot slot carries PV (never a night booking).
+    assert all(
+        inputs.slots[i].pv_wh > 0.0 for i, on in enumerate(fb_plan.schedule) if on
+    )
 
-    # (b) The fossibot never causes import beyond the trade contract (L5). The
-    #     +49 Wh that fb's presence now costs is financed by the DEHUMIDIFIER's
-    #     own trade budget (a shared-pool attribution artifact), so the binding
-    #     guarantees are the two trade-gate invariants below — both green.
+    # (b) Import stays bounded by the trade contract for the WHOLE plan. The
+    #     binding guarantees are the two trade-gate invariants below.
     ratio = control.import_trade_ratio
-    assert fb_plan.planned_energy_wh < 6000.0  # would-add-import top-up declined
+    assert fb_plan.planned_energy_wh < 6000.0  # gates still bound the top-up
     # (b1) Cumulative trade invariant over the whole plan vs the no-loads base.
     assert traj.total_import_wh - base.total_import_wh <= (
         ratio * (base.total_export_wh - traj.total_export_wh) + 1.0 + 1e-6
@@ -1576,6 +1629,227 @@ def test_fix2_energy_limited_books_surplus_after_continuous_trade():
     without_fb = simulate(cfg, inputs, threshold, extra_ac_wh=tuple(deh_only))
     assert traj.total_import_wh - without_fb.total_import_wh <= (
         ratio * (without_fb.total_export_wh - traj.total_export_wh) + 1.0 + 1e-6
+    )
+
+
+# ---------------------------------------------------------------------------
+# F-GATE-PARITY (operator decision 2026-07-17): both load classes face the
+# identical pass-2 gate set (shared Z2' trade, c1-rt, c2-beta, Z4 stress);
+# the priority order (config order) alone decides contested bet energy.
+# Single remaining class rule: energy-limited loads never book zero-PV
+# (night) slots — nights stay reserved for continuous loads.
+# ---------------------------------------------------------------------------
+
+
+def _parity_scene(start_soc_wh: float, loads):
+    """Two-slot bet scene: a weakly lit make-room slot (06:00, 10 Wh dawn
+    light) ahead of one big clipping slot (07:00). The c1 refill pool is
+    huge; bet depth is scarce because the simulator's inverter cutoff at
+    T*=20 % (400 Wh of the 2000 Wh battery) turns any deeper drain into
+    grid import, which the Z2' trade budget cannot finance — at 800 Wh
+    start there is room for exactly ONE ~326 Wh battery drain (one 300 Wh
+    AC booking), and a second booking of ANY quantum falls through the
+    cutoff and is rejected. Who gets the one booking is purely a question
+    of config order."""
+    control = replace(
+        ControlParams(),
+        import_trade_ratio=0.1,
+        predrain_pv_confidence=0.5,
+        upper_pv_reserve=1.0,
+        strong_pv_cutoff_w=200.0,
+    )
+    cfg = SystemConfig(
+        control=control,
+        loads=loads,
+        battery=BatteryParams(capacity_wh=2000.0),
+        ac_profile=LoadProfile(0.0, 0.0),
+        dc_profile=LoadProfile(0.0, 0.0),
+    )
+    start = datetime(2026, 7, 4, 6, 0)
+
+    def slot(i, hour, pv):
+        return HourSlot(
+            index=i,
+            start=start + timedelta(hours=i),
+            duration=1.0,
+            hour_of_day=hour,
+            pv_wh=pv,
+            ac_wh=0.0,
+            dc_wh=0.0,
+        )
+
+    slots = (slot(0, 6, 10.0), slot(1, 7, 2500.0), slot(2, 8, 100.0))
+    states = tuple(
+        SurplusLoadState(load_id=ld.load_id, soc_percent=0.0)
+        if ld.energy_limited
+        else SurplusLoadState(load_id=ld.load_id)
+        for ld in loads
+    )
+    inputs = PlanInputs(
+        now=start,
+        start_soc_percent=start_soc_wh / 2000.0 * 100.0,
+        slots=slots,
+        load_states=states,
+    )
+    threshold, base = search_threshold(cfg, inputs)
+    plans, _extra, _traj = allocate_loads(cfg, inputs, threshold, base)
+    return plans
+
+
+_DEH300 = SurplusLoad(
+    load_id="deh300",
+    name="Entfeuchter 300",
+    nominal_power_w=300.0,
+    battery_tolerance=0.05,
+)
+
+
+def _books_slot0_pass2(plans, load_id):
+    lp = next(p for p in plans if p.load_id == load_id)
+    return any(a[0] == 0 and a[2] == 2 for a in lp.allocations)
+
+
+def test_gate_parity_contested_bet_goes_to_priority_one():
+    """The depth-capped bet slot (room for ONE 300 Wh booking above the
+    inverter cutoff) goes to whichever load is FIRST in config order — the
+    energy-limited powerstation wins it when it holds priority 1, the
+    continuous load wins it when the order is swapped. Priority, not load
+    class, decides."""
+    fb = replace(FOSSIBOT_B, target_soc_percent=100.0)
+    # 800 Wh start: one ~326 Wh drain lands at ~474 Wh (above the 400 Wh
+    # cutoff); any second quantum would fall through it — room for one bet.
+    # Powerstation first: it takes the bet, the dehumidifier is floor-blocked.
+    plans = _parity_scene(800.0, (fb, _DEH300))
+    assert _books_slot0_pass2(plans, "fossibot_b")
+    assert not _books_slot0_pass2(plans, "deh300")
+    # Swapped order: the same slot goes to the dehumidifier instead.
+    plans = _parity_scene(800.0, (_DEH300, fb))
+    assert _books_slot0_pass2(plans, "deh300")
+    assert not _books_slot0_pass2(plans, "fossibot_b")
+
+
+def test_gate_parity_z4_stress_binds_energy_limited_bets():
+    """Z4 now gates energy-limited bets too. The bet must end in the gap
+    between the inverter cutoff (20 % = 400 Wh) and the RAMPED stress floor
+    (20 % + 5 % buffer = 500 Wh; the buffer ramps with the slot's stressed
+    house deficit, so the bet slot carries 200 Wh of house load): a 950 Wh
+    start minus ~217 Wh house minus ~326 Wh bet lands at ~407 Wh — above
+    the cutoff (no import, c1/Z2'/Z3 all pass) but below the stressed
+    floor. alpha=0.5 rejects the full quantum (the half-quantum, landing
+    at ~570 Wh, may still book); alpha=1.0 disables the gate and books the
+    full quantum — Z4 is the only discriminating constraint."""
+    fb = replace(FOSSIBOT_B, target_soc_percent=100.0)
+
+    def run(alpha):
+        control = replace(
+            ControlParams(),
+            import_trade_ratio=0.1,
+            predrain_pv_confidence=alpha,
+            upper_pv_reserve=1.0,
+            strong_pv_cutoff_w=200.0,
+        )
+        cfg = SystemConfig(
+            control=control,
+            loads=(fb,),
+            battery=BatteryParams(capacity_wh=2000.0),
+            ac_profile=LoadProfile(0.0, 0.0),
+            dc_profile=LoadProfile(0.0, 0.0),
+        )
+        start = datetime(2026, 7, 4, 6, 0)
+        slots = tuple(
+            HourSlot(
+                index=i,
+                start=start + timedelta(hours=i),
+                duration=1.0,
+                hour_of_day=6 + i,
+                pv_wh=pv,
+                ac_wh=ac,
+                dc_wh=0.0,
+            )
+            for i, (pv, ac) in enumerate(((10.0, 200.0), (2500.0, 0.0), (100.0, 0.0)))
+        )
+        inputs = PlanInputs(
+            now=start,
+            start_soc_percent=47.5,  # 950 Wh
+            slots=slots,
+            load_states=(SurplusLoadState(load_id="fossibot_b", soc_percent=0.0),),
+        )
+        threshold, base = search_threshold(cfg, inputs)
+        plans, _extra, _traj = allocate_loads(cfg, inputs, threshold, base)
+        return sum(
+            a[3]
+            for p in plans
+            if p.load_id == "fossibot_b"
+            for a in p.allocations
+            if a[0] == 0 and a[2] == 2
+        )
+
+    stressed_p2 = run(0.5)
+    trusting_p2 = run(1.0)
+    assert trusting_p2 >= 300.0 - 1e-6, (
+        f"alpha=1.0 must book the full quantum, got {trusting_p2}"
+    )
+    assert stressed_p2 <= 150.0 + 1e-6, (
+        f"alpha=0.5 must cap the slot-0 bet below the full quantum, got {stressed_p2}"
+    )
+    assert stressed_p2 < trusting_p2  # the stress gate visibly bound
+
+
+def test_gate_parity_daylight_rule_blocks_fb_night_predrain():
+    """Maximum temptation (generous ratio, hungry powerstation, T1-shaped
+    horizon whose night pre-drain a continuous load DOES book): the
+    energy-limited load never books a zero-PV slot — only the daylight rule
+    separates the classes now."""
+    now = datetime(2026, 7, 3, 21, 0)
+    fb_hungry = replace(FOSSIBOT_B, capacity_wh=8000.0, target_soc_percent=100.0)
+    cfg = _predrain_config(ratio=0.5, alpha=1.0, beta=1.0, loads=(fb_hungry,))
+    states = (SurplusLoadState(load_id="fossibot_b", soc_percent=0.0),)
+    result, inputs = make_plan(cfg, now, 84.0, [0.0, 13.0, 11.0], load_states=states)
+    # Guard against a vacuous pass: the hungry fossibot must book SOMETHING
+    # (its daylight hours) — only then does the night exclusion mean anything.
+    assert result.load_plans[0].planned_energy_wh > 0.0
+    for i, on in enumerate(result.load_plans[0].schedule):
+        if on:
+            assert inputs.slots[i].pv_wh > 0.0, (
+                f"fossibot booked zero-PV slot at {inputs.slots[i].hour_of_day}:00"
+            )
+    # Contrast: the SAME horizon books night hours for a continuous load —
+    # the c1/Z2' gates admit them, so only the daylight rule blocked fb.
+    deh_cfg = _predrain_config(ratio=0.5, alpha=1.0, beta=1.0)
+    deh_res, deh_in = make_plan(deh_cfg, now, 84.0, [0.0, 13.0, 11.0])
+    night = [h for h in _dehumid_hours(deh_res, deh_in) if not daylight_h(h)]
+    assert night, "contrast: the continuous load must book the night pre-drain"
+
+
+def test_gate_parity_c2_beta_books_energy_limited_in_window():
+    """T12 parity: the optimistic c2 gate now opens extra in-window slots for
+    an energy-limited load exactly as it does for the dehumidifier — reason
+    string included — while the trade invariant keeps holding."""
+    now = datetime(2026, 7, 4, 8, 0)
+    fb_hungry = replace(FOSSIBOT_B, capacity_wh=8000.0, target_soc_percent=100.0)
+    states = (SurplusLoadState(load_id="fossibot_b", soc_percent=0.0),)
+
+    def run(beta):
+        cfg = _predrain_config(ratio=0.1, alpha=1.0, beta=beta, loads=(fb_hungry,))
+        return make_plan(cfg, now, 92.0, [7.0], load_states=states)
+
+    r10, inputs = run(1.0)
+    r12, _ = run(1.2)
+    booked10 = {i for i, on in enumerate(r10.load_plans[0].schedule) if on}
+    booked12 = {i for i, on in enumerate(r12.load_plans[0].schedule) if on}
+    extra = booked12 - booked10
+    assert extra, "beta=1.2 must open extra in-window slots for the fossibot"
+    windows = pv_windows(inputs, 200.0, None)
+    for i in extra:
+        w = windows[inputs.slots[i].start.date()]
+        assert w[0] <= i <= w[1], f"c2 slot {i} not inside its PV window {w}"
+        assert inputs.slots[i].pv_wh > 0.0
+    assert any("in-window insurance" in r for r in r12.load_plans[0].reasons)
+    cfg12 = _predrain_config(ratio=0.1, alpha=1.0, beta=1.2, loads=(fb_hungry,))
+    _, base = search_threshold(cfg12, inputs)
+    traj = r12.trajectory
+    assert traj.total_import_wh - base.total_import_wh <= (
+        0.1 * (base.total_export_wh - traj.total_export_wh) + 1.0 + 1e-6
     )
 
 


### PR DESCRIPTION
Operator decision 2026-07-17 (F-GATE-PARITY): the pass-2 class asymmetry was a spec error — continuous loads could take bet energy (import trade, c2-beta, Z4-stressed make-room) that energy-limited loads were forbidden, de-facto overriding the per-load priority order. New binding rule: **"Priorität immer — lieber den Fossibot laden, als den Luftentfeuchter betreiben, wenn die Wahl besteht."**

## What changed
- **One Z2' trade invariant for ALL loads** (base-anchored); the strict current-anchored energy-limited branch (FIX-2) is superseded — mini import artifacts no longer veto fossibot bookings the dehumidifier could take.
- **c1-rt / c2-beta / Z4 bind both classes identically**; priority (config order) alone decides contested energy.
- **Single remaining class rule:** energy-limited loads never book zero-PV (night) slots. Daylight predicate `pv_wh > 0` — deliberately NOT the strong-PV window, so dawn-light pre-charges before a short peak stay allowed (operator refinement 2: "nachts nur Entfeuchter").
- `stressed_min_soc_percent` now covers pass-2 bookings of any load (observability semantics change).
- Intended consequence: the dehumidifier's night pre-drain may shrink on days a hungry fossibot consumes the shared trade/c2 budget first.

## Verification
- **Goldens:** 10/11 topology scenarios + the entire night-predrain golden **bit-identical**. Only `short_peak_preempt` changed (−900 Wh planned, import unchanged): its synthetic two-window PV has exactly 0 Wh before the window, which the night rule correctly excludes; live hourly forecasts always carry dawn light — the adapted tests model 5 Wh twilight explicitly.
- **5 new gate-parity tests:** contested bet slot follows config order (swap order → other winner); Z4 caps bet depth via quantum fallback; night-exclusion pin under maximum temptation; c2-beta parity incl. reason string; shared trade budget (fossibot 1800 → 2250 Wh).
- Core suite (170) + full WSL HA suite green; ruff clean; versions synced 0.13.0.
- Adversarial multi-agent review (13 agents): **0 correctness bugs**; 8 low findings (stale docstring, doc-consistency in 4 specs, 1 test hardening) all fixed in this branch.

Spec: `docs/F-GATE-PARITY.md` (operator quote, GP-R1…R4, golden classification, supersedes list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)