### PR TITLE
Release v0.13.1: G4 floor guard — surplus loads never run grid-fed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-18
+
+### Fixed
+- **Surplus loads could run grid-fed at the inverter floor (G4 floor
+  guard).** Incident 2026-07-18 06:20-06:30: the plan deactivated a booked
+  dehumidifier run, but the min_runtime ON→OFF dwell held the switch for
+  another 10 minutes while the battery hit the 20 % inverter cutoff — the
+  real inverter shut down and the 432 W load drew from the GRID. New binding
+  operator rule: when the inverter is off or the SOC reaches the inverter
+  floor, surplus loads must not be actuated. The executor now computes a
+  floor guard every cycle (SOC at/below `inverter_min_soc_percent` OR
+  inverter recommendation off): running controlled loads are forced off
+  dwell-exempt (min_off still gates the re-on), nothing switches on, the
+  published per-load `active` and the appliance start-window advisory read
+  False (operator automations stop too). The SOC branch latches and releases
+  only at floor + `hysteresis_percent` (no flapping at the floor); reaction
+  time is the ~5 s debounced SOC refresh instead of up to a full dwell.
+  Surfaced as `floor_guard_active` on the inverter-recommendation sensor.
+  Planner unchanged — G4 is the hard executor backstop against forecast
+  error (docs/LOAD_CONTROL.md §11, spec docs/F-EXECUTOR-GUARDS.md G4; named
+  G4 — G1-G3 were taken). Review hardening: queued switch-ONs are dropped
+  when the guard trips while a switch task is in flight (plus a catch-up
+  refresh for the deferred forced OFF); trip/release stay disjoint even at
+  `hysteresis_percent` 0; runtime accrual and the power warning treat loads
+  as inactive during a guard episode (no false 0 W "full tank" warning).
+
 ## [0.13.0] - 2026-07-18
 
 ### Changed
@@ -270,7 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target cannot flap the switch.
 
 ### Fixed
-- **Deprecated coordinator init (F-EXECUTOR-GUARDS G3).** The
+- **Deprecated coordinator init (F-EXECUTOR-GUARDS G4).** The
   `DataUpdateCoordinator` is now constructed with `config_entry=` — newer HA
   cores hard-error on the implicit ContextVar lookup.
 

--- a/custom_components/battery_manager/binary_sensor.py
+++ b/custom_components/battery_manager/binary_sensor.py
@@ -125,7 +125,13 @@ class InverterRecommendationSensor(BatteryManagerEntity, BinarySensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         data = self.coordinator.data or {}
-        return {ATTR_THRESHOLD: data.get("soc_threshold_percent")}
+        return {
+            ATTR_THRESHOLD: data.get("soc_threshold_percent"),
+            # G4: True while surplus loads are forced off/blocked because
+            # they would run grid-fed (SOC at the inverter floor or
+            # recommendation off) — for diagnostics and operator automations.
+            "floor_guard_active": data.get("floor_guard_active"),
+        }
 
 
 class SurplusLoadRecommendationSensor(BatteryManagerEntity, BinarySensorEntity):

--- a/custom_components/battery_manager/coordinator.py
+++ b/custom_components/battery_manager/coordinator.py
@@ -336,6 +336,11 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._load_plug_owned: dict[str, bool] = {}
         self._last_load_switch: dict[str, datetime] = {}
         self._load_charging_active: dict[str, bool] = {}
+        # G4 floor guard (operator rule 2026-07-18): True while surplus loads
+        # are barred from running because they would be grid-fed. None until
+        # the first update cycle computed it (treated as inactive by readers;
+        # the first computation itself initialises conservatively).
+        self._floor_guard_active: bool | None = None
         # Last plan's slot-0 activation per load: the learning gate for
         # recommendation-only loads (no control switch), see _bm_load_active.
         # _load_learn_ok snapshots at each activation edge whether the
@@ -1071,7 +1076,13 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     DEFAULT_LOAD_CONFIG[CONF_LOAD_POWER_WARNING_DWELL_MIN],
                 )
             )
-            if subentry_id in self._load_charging_active:
+            if self._floor_guard_active:
+                # G4: under the floor guard no load runs at BM's request —
+                # a recommendation-only load stopped by the operator's
+                # automation must not trip a 0 W "full tank" warning while
+                # its plan flag is nominally still active.
+                active = False
+            elif subentry_id in self._load_charging_active:
                 active = self._load_charging_active[subentry_id]
             else:
                 active = active_by_id.get(subentry_id, False)
@@ -1331,6 +1342,12 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     pass
         if load_id in self._load_charging_active:
             return bool(self._load_charging_active[load_id])
+        # G4: the plan-based fallback (recommendation-only loads without a
+        # power reading) must not accrue runtime while the floor guard holds
+        # everything off — the published `active` the operator follows is
+        # False, so the device is not running at BM's request.
+        if self._floor_guard_active:
+            return False
         if not self._load_plan_active.get(load_id, False):
             return False
         deadline = self._load_run_deadline.get(load_id)
@@ -1833,6 +1850,9 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         threshold = self._apply_threshold_inertia(result.threshold_percent, config)
         recommendation = self._apply_hysteresis(soc, threshold, config, now)
+        # G4 floor guard: needs the just-updated recommendation; must run
+        # BEFORE load switching so this cycle already enforces it.
+        floor_guard = self._update_floor_guard(soc, config)
         await self._apply_support_switching(result, config, now)
         self._run_dc48_controller(now)
         await self._apply_load_switching(
@@ -1980,6 +2000,8 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "input_forecasts_kwh": forecasts,
             "soc_threshold_percent": threshold,
             "inverter_recommendation": recommendation,
+            # G4 floor guard: surfaced for diagnostics and operator automations.
+            "floor_guard_active": floor_guard,
             "min_soc_forecast_percent": result.min_soc_percent,
             "max_soc_forecast_percent": result.max_soc_percent,
             "hours_to_max_soc": result.hours_to_max_soc,
@@ -2020,7 +2042,12 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "inverter_min_soc_percent": config.control.inverter_min_soc_percent,
                 "soc_buffer_percent": config.control.soc_buffer_percent,
             },
-            "appliance_windows": dict(result.appliance_windows),
+            # G4: while the floor guard is active an appliance start would run
+            # grid-fed too — the advisory must not invite one.
+            "appliance_windows": {
+                k: (bool(v) and not floor_guard)
+                for k, v in result.appliance_windows.items()
+            },
             "support_dc24": self._support_state["dc24"],
             "support_dc48": self._support_state["dc48"],
             "support_dc24_mode": "manual" if self._support_manual["dc24"] else "auto",
@@ -2908,19 +2935,80 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if now >= deadline + timedelta(minutes=min_off):
             _anchor()
 
+    def _update_floor_guard(self, soc: float, config: SystemConfig) -> bool:
+        """G4 floor guard (F-EXECUTOR-GUARDS, operator rule 2026-07-18):
+        surplus loads must NEVER run grid-fed — "Wenn der Inverter aus ist
+        oder der SOC 20 % erreicht, dürfen Zusatzlasten nicht mehr
+        angesteuert werden."
+
+        Trips when the battery SOC reaches the inverter-cutoff floor
+        (`inverter_min_soc_percent`; the real inverter shuts down there, so
+        any still-running load falls onto the grid — the 2026-07-18 06:21
+        incident: 432 W dehumidifier grid-fed for ~10 min because only the
+        min_runtime dwell timed the OFF) OR while the inverter
+        recommendation is off (a T*-driven shutdown routes the house — and
+        any load — to grid). The SOC branch LATCHES: it releases only at
+        `floor + hysteresis_percent`, so a SOC hovering at the floor cannot
+        flap the loads. A restart inside the release band starts latched
+        (conservative). Must run AFTER `_apply_hysteresis` so the
+        recommendation member is fresh for this cycle.
+        """
+        floor = config.control.inverter_min_soc_percent
+        hyst = max(0.0, config.control.hysteresis_percent)
+        prev = self._floor_guard_active
+        if prev is None or prev:
+            # Release threshold (and restart init): strictly ABOVE the floor
+            # even at hysteresis 0 — otherwise trip (<= floor) and release
+            # (< floor + 0) would overlap at exactly the floor SOC (a
+            # persistent state: the inverter cuts off there) and the guard
+            # would flap every cycle, re-enabling loads at the floor.
+            soc_low = soc <= floor or soc < floor + hyst
+        else:
+            soc_low = soc <= floor  # trip threshold
+        guard = soc_low or not self._inverter_recommendation
+        if guard and not prev:
+            _LOGGER.warning(
+                "Floor guard TRIPPED (%s): surplus loads are forced off and"
+                " blocked until SOC recovers above %.1f %% with the inverter"
+                " recommendation on (G4)",
+                f"SOC {soc:.1f} % at the {floor:.0f} % inverter floor"
+                if soc_low
+                else "inverter recommendation off",
+                floor + hyst,
+            )
+        elif prev and not guard:
+            _LOGGER.info(
+                "Floor guard released at SOC %.1f %% — surplus loads may run again",
+                soc,
+            )
+        self._floor_guard_active = guard
+        return guard
+
     def _effective_load_active(self, load_plan, now: datetime) -> bool:
         """Published `active` for the load binary sensor: the whole-slot
-        `active_now` capped by the frozen sub-hour deadline (F-SUBHOUR)."""
+        `active_now` capped by the frozen sub-hour deadline (F-SUBHOUR) and
+        forced off entirely while the G4 floor guard is active — the
+        operator's own automations follow this flag, and they must stop
+        with the executor (a grid-fed run is forbidden either way)."""
+        if self._floor_guard_active:
+            return False
         deadline = self._load_run_deadline.get(load_plan.load_id)
         return bool(load_plan.active_now) and (deadline is None or now < deadline)
 
     async def _apply_load_switching(
         self, result, now: datetime, slot_durations: tuple[float, ...] | None = None
     ) -> None:
-        """Evaluate controlled loads and start switching where needed."""
+        """Evaluate controlled loads and start switching where needed.
+
+        While the G4 floor guard is active (SOC at the inverter floor or
+        inverter recommendation off, `_update_floor_guard`), every controlled
+        load is forced OFF dwell-exempt and nothing switches ON — a surplus
+        load must never run grid-fed (operator rule 2026-07-18).
+        """
         if self._load_switch_task is not None and not self._load_switch_task.done():
             return
 
+        floor_guard = bool(self._floor_guard_active)
         plans_by_id = {lp.load_id: lp for lp in result.load_plans}
         actions: list[tuple[str, dict[str, Any], bool, bool, float]] = []
         for subentry_id, subentry in self.entry.subentries.items():
@@ -2952,7 +3040,10 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # against ~150 Wh of validated energy. The min_off dwell then blocks
             # an immediate re-on (duty-cycling).
             deadline = self._load_run_deadline.get(subentry_id)
-            if current and deadline is not None and now >= deadline:
+            if floor_guard:
+                # G4: grid-fed operation is forbidden — force OFF, block ON.
+                desired = False
+            elif current and deadline is not None and now >= deadline:
                 desired = False
             else:
                 desired = active_now
@@ -2963,6 +3054,13 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # latter protects compressor loads from short-cycling.
             if current:  # pending switch OFF
                 dwell_min = int(data.get(CONF_LOAD_MIN_RUNTIME_MIN, 30))
+                if floor_guard:
+                    # G4: the floor-guard OFF is dwell-EXEMPT — every dwell
+                    # minute runs the load grid-fed (the 06:21 incident lost
+                    # ~10 min × 432 W exactly to this hold). The confirmed
+                    # switch still stamps the dwell timestamp, so min_off
+                    # fully gates the later re-on (compressor protection).
+                    dwell_min = 0
                 # F-EXECUTOR-GUARDS G1 (R1-R3): a target-SOC stop of an
                 # energy-limited load with a charge-enable gate is dwell-
                 # EXEMPT. min_runtime protects relays/compressors from short
@@ -3029,6 +3127,18 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 enable = data.get(CONF_LOAD_CHARGE_ENABLE)
                 subentry = self.entry.subentries.get(subentry_id)
                 label = subentry.title if subentry else subentry_id
+                if activate and self._floor_guard_active:
+                    # G4 floor guard, in-flight race: the guard may have
+                    # tripped AFTER this ON was queued (a debounced SOC
+                    # refresh returns early while this task is still
+                    # running). A queued ON must never fire at/below the
+                    # floor — that is exactly the grid-fed start the guard
+                    # exists to prevent.
+                    _LOGGER.info(
+                        "Floor guard active: dropping queued switch-ON for %s",
+                        label,
+                    )
+                    continue
                 if activate:
                     if enable and not await self._switch_entity(enable, True):
                         continue
@@ -3113,6 +3223,13 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if load_id in plans:
                     plans[load_id]["charging_active"] = active
             self.async_update_listeners()
+        if self._floor_guard_active:
+            # G4, in-flight race (part 2): a refresh that tripped the guard
+            # while this task was running returned early and could not queue
+            # its forced OFFs. Re-run the cycle now so any load that this
+            # task just switched on (or that is still running) is forced off
+            # immediately instead of waiting for the next poll.
+            await self.async_request_refresh()
 
     # ------------------------------------------------------------------
     # Entity listeners

--- a/custom_components/battery_manager/manifest.json
+++ b/custom_components/battery_manager/manifest.json
@@ -1,14 +1,22 @@
 {
   "domain": "battery_manager",
   "name": "Battery Manager",
-  "after_dependencies": ["frontend", "lovelace", "recorder"],
-  "codeowners": ["@danielr0815"],
+  "after_dependencies": [
+    "frontend",
+    "lovelace",
+    "recorder"
+  ],
+  "codeowners": [
+    "@danielr0815"
+  ],
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": [
+    "http"
+  ],
   "documentation": "https://github.com/danielr0815/battery-manager-ha",
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danielr0815/battery-manager-ha/issues",
   "requirements": [],
-  "version": "0.13.0"
+  "version": "0.13.1"
 }

--- a/docs/F-EXECUTOR-GUARDS.md
+++ b/docs/F-EXECUTOR-GUARDS.md
@@ -95,3 +95,43 @@ Full suite green on `.venv314` (winshim), ruff check AND format check (0.15.21).
 Goldens MUST be byte-identical (coordinator-only change). docs/LOAD_CONTROL.md:
 short sections for the target-stop dwell exemption and the stale-SOC guard.
 CHANGELOG under [Unreleased]; release cut as v0.9.0 together with part 1.
+
+## G4 — Floor guard: surplus loads never run grid-fed (v0.13.1)
+
+Binding operator rule (2026-07-18, after the 06:20-06:30 incident — a booked
+dehumidifier run stayed grid-fed for ~10 min at the 20 % inverter cutoff
+because only the min_runtime dwell timed the OFF): **"Wenn der Inverter aus
+ist oder der SOC 20 % erreicht, dürfen Zusatzlasten nicht mehr angesteuert
+werden."**
+
+- **R12** `_update_floor_guard(soc, config)` runs every cycle directly after
+  `_apply_hysteresis`. Trip: `soc <= inverter_min_soc_percent` OR inverter
+  recommendation off ("Inverter aus" is deliberately implemented as the
+  RECOMMENDATION, not the physical inverter state — BM has no inverter state
+  entity; the SOC branch catches the physical cutoff case, the recommendation
+  branch the T*-driven one). The WHOLE guard latches: release requires the
+  SOC strictly above the floor AND `>= floor + hysteresis_percent` (the
+  strict-floor clause keeps trip/release disjoint even at hysteresis 0) AND
+  the recommendation on. Restart inside the release band starts latched.
+- **R13** Enforcement in `_apply_load_switching`: `desired = False` for every
+  controlled load, ON->OFF dwell-exempt (G1 precedent; the confirmed OFF
+  stamps the dwell so min_off gates the re-on). `_execute_load_switching`
+  re-checks the guard per action and DROPS queued switch-ONs (in-flight race:
+  a trip during a running switch task must not let a pre-trip ON fire), and
+  requests a refresh after the task when the guard is active (the early
+  in-flight return in the tripping cycle could not queue its forced OFFs).
+- **R14** Published state follows: `_effective_load_active` returns False
+  (operator automations and recommendation-only loads stop; note: for
+  recommendation-only loads there is no BM-side min_off after a guard stop —
+  the release hysteresis is the only flap brake, documented semantics), the
+  appliance start-window advisory reads False, runtime accrual's plan-based
+  fallback stops, and `_update_power_warnings` treats all loads as inactive
+  (no 0 W "full tank" false positive during a guard episode). Surfaced as
+  `floor_guard_active` (coordinator data + inverter-recommendation sensor
+  attribute).
+- **R15 (tests)** Force-off despite min_runtime; no ON under guard; latch
+  trip/hold/release incl. hysteresis-0 disjointness; recommendation-off trip;
+  restart-in-band latched; published active capped; end-to-end refresh at
+  SOC below floor -> guard active + appliance advisory False; queued-ON drop.
+
+Supersedes F-SUBHOUR R9's "never off before min_runtime" for the guard case.

--- a/docs/F-PREDRAIN.md
+++ b/docs/F-PREDRAIN.md
@@ -34,6 +34,11 @@ integration, 15-min buckets) are ignored.
 - **L1** Small modeling artifacts (10 Wh standby) must never veto sensible
   battery use.
 - **L2** Always keep enough energy above the 20 % inverter-cutoff SOC.
+  Since v0.13.1 the executor additionally enforces this as a hard backstop:
+  at the cutoff (or with the inverter recommendation off) all surplus loads
+  are forced off dwell-exempt and blocked — a pre-drain bet that loses to
+  forecast error can no longer run grid-fed (F-EXECUTOR-GUARDS G4,
+  docs/LOAD_CONTROL.md §11).
 - **L3** The LOWER buffer (inverter reserve) is time-of-day dependent: it may
   shrink toward the forecast solar onset.
 - **L4** "As late as possible" stands: preemptive runs as late as the

--- a/docs/F-SUBHOUR-ALLOCATION.md
+++ b/docs/F-SUBHOUR-ALLOCATION.md
@@ -93,6 +93,10 @@ simulator (already energy‑ and duration‑exact). No sub‑`min_runtime` runs
   The force‑off uses the existing OFF path and stamps `_last_load_switch` (dwell).
 - **R9** The load is also switched off earlier if a later plan makes it inactive
   once past the dwell (surplus vanished), and **never** off before `min_runtime`.
+  (Since v0.13.1 ONE exception overrides this: the G4 floor guard forces an
+  immediate dwell-exempt OFF when the battery hits the inverter floor or the
+  inverter recommendation is off — a grid-fed run is forbidden,
+  docs/F-EXECUTOR-GUARDS.md G4.)
 - **R10** After a forced off the `min_runtime` dwell blocks immediate re‑on; a
   later surplus window re‑activates the load (duty‑cycling across export windows,
   e.g. dehumidifier 16:00–16:30 and 17:00–17:30).

--- a/docs/LOAD_CONTROL.md
+++ b/docs/LOAD_CONTROL.md
@@ -238,3 +238,39 @@ when charging stops or the sample bar is not met (an end-of-charge taper never
 accumulates false evidence), and loads without a SOC or power-feedback entity
 never latch. In-memory only — a restart re-detects within minutes. The
 per-load diagnostics expose `soc_stale`.
+
+## 11. Floor guard — surplus loads never run grid-fed (v0.13.1)
+
+F-EXECUTOR-GUARDS G4, binding operator rule (2026-07-18): **"Wenn der
+Inverter aus ist oder der SOC 20 % erreicht, dürfen Zusatzlasten nicht mehr
+angesteuert werden."** Incident that forced it: on 2026-07-18 06:20 the plan
+deactivated a booked dehumidifier run, but the min_runtime ON→OFF dwell held
+the switch until 06:30 while the battery hit the 20 % inverter cutoff at
+06:21 — the real inverter shut down and the 432 W load ran ~10 min on GRID.
+No executor path checked SOC or inverter state; the recommendation itself
+stayed ON at SOC 20.0 (its ±1 % hysteresis flips only at 19).
+
+Mechanics (`_update_floor_guard`, computed each cycle right after
+`_apply_hysteresis`): the guard trips when the battery SOC is at/below
+`inverter_min_soc_percent` OR the inverter RECOMMENDATION is off ("Inverter
+aus" is deliberately the recommendation, not the physical inverter state —
+BM has no inverter state entity; the SOC branch catches the physical cutoff,
+the recommendation branch the T*-driven shutdowns). While active,
+`_apply_load_switching` forces every controlled load OFF **dwell-exempt**
+(the G1 precedent: safety overrides min_runtime; the confirmed switch still
+stamps the dwell so min_off fully gates the re-on), never switches one ON,
+and the executor drops even already-QUEUED switch-ONs (in-flight race); the
+published per-load `active` reads False (operators' own automations and
+recommendation-only loads stop too — note that recommendation-only loads
+have no BM-side min_off after a guard stop, the release hysteresis is their
+only flap brake), the appliance start-window advisory reads False (a start
+would import), runtime accrual's plan-based fallback pauses and the power
+warning treats all loads as inactive (no 0 W false positive). The WHOLE
+guard LATCHES: release requires the SOC strictly above the floor and at
+`inverter_min + hysteresis_percent` (default +1 %; strictly-above keeps
+trip/release disjoint even at hysteresis 0) with the recommendation on; a
+restart inside the release band starts latched (conservative). Reaction
+time is the SOC entity's debounced refresh (~5 s), not the dwell. In-memory
+only; surfaced as `floor_guard_active` on the inverter-recommendation
+binary sensor. The planner is deliberately unchanged — G4 is the hard
+executor backstop against forecast error, not a planning rule.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "battery-manager-ha"
-version = "0.13.0"
+version = "0.13.1"
 description = "Solar-battery optimizer for Home Assistant: SOC forecast, discharge-threshold planning, surplus-load and grid-support control."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -809,6 +809,88 @@ async def test_refresh_awaits_power_warning_update(hass):
     assert ran, "_async_update_data must await _update_power_warnings"
 
 
+async def test_refresh_at_floor_soc_activates_guard_end_to_end(hass):
+    """G4 end-to-end: a real refresh at SOC 19 % (below the 20 % inverter
+    floor) trips the floor guard inside the cycle — the published
+    diagnostics and the per-load `active` all read guarded, so operator
+    automations stop with the executor."""
+    coordinator, _titles = await _setup_entry_with_load_data(
+        hass, [("F1", {"power_w": 300.0})]
+    )
+    hass.states.async_set(
+        "sensor.test_soc", "19", {"unit_of_measurement": "%", "device_class": "battery"}
+    )
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    data = coordinator.data
+    assert data["floor_guard_active"] is True
+    assert coordinator._floor_guard_active is True
+    for lp in data["load_plans"].values():
+        assert lp["active"] is False
+    # appliance advisory gating is pinned load-bearingly (baseline True ->
+    # guarded False) in test_floor_guard_gates_appliance_advisory_end_to_end.
+
+
+async def test_floor_guard_gates_appliance_advisory_end_to_end(hass):
+    """G4: the appliance start-window advisory flips to False under the
+    guard — pinned load-bearingly against a baseline where the SAME
+    appliance advisory is True (high SOC, strong PV)."""
+    from homeassistant.config_entries import ConfigSubentryData
+
+    from custom_components.battery_manager.const import (
+        CONF_APPLIANCE_NAME,
+        CONF_APPLIANCE_OPPORTUNISTIC,
+        CONF_APPLIANCE_RUN_DURATION_H,
+        CONF_APPLIANCE_RUN_ENERGY_WH,
+        SUBENTRY_TYPE_APPLIANCE,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=ENTRY_DATA,
+        title="Battery Manager",
+        version=2,
+        subentries_data=[
+            ConfigSubentryData(
+                data={
+                    CONF_APPLIANCE_NAME: "DW",
+                    CONF_APPLIANCE_OPPORTUNISTIC: True,
+                    CONF_APPLIANCE_RUN_ENERGY_WH: 500.0,
+                    CONF_APPLIANCE_RUN_DURATION_H: 1.0,
+                },
+                subentry_type=SUBENTRY_TYPE_APPLIANCE,
+                title="DW",
+                unique_id=None,
+            )
+        ],
+    )
+    entry.add_to_hass(hass)
+    _set_input_states(hass)
+    hass.states.async_set(
+        "sensor.test_soc", "93", {"unit_of_measurement": "%", "device_class": "battery"}
+    )
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    baseline = coordinator.data["appliance_windows"]
+    assert baseline and any(baseline.values()), (
+        f"scenario must produce a True advisory as baseline, got {baseline}"
+    )
+
+    hass.states.async_set(
+        "sensor.test_soc", "19", {"unit_of_measurement": "%", "device_class": "battery"}
+    )
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    data = coordinator.data
+    assert data["floor_guard_active"] is True
+    assert data["appliance_windows"] and all(
+        v is False for v in data["appliance_windows"].values()
+    )
+
+
 # ---------------------------------------------------------------------------
 # F-PERDAY-SURPLUS: per-calendar-day lost-surplus / grid-import breakdown
 # (docs/F-PERDAY-SURPLUS.md R1-R3).

--- a/tests/ha/test_load_switching.py
+++ b/tests/ha/test_load_switching.py
@@ -1775,6 +1775,198 @@ async def test_plan_flap_does_not_switch_off_before_min_runtime(hass):
 
 
 # ---------------------------------------------------------------------------
+# F-EXECUTOR-GUARDS G4 — floor guard (operator rule 2026-07-18): "Wenn der
+# Inverter aus ist oder der SOC 20 % erreicht, dürfen Zusatzlasten nicht mehr
+# angesteuert werden." Incident: a booked dehumidifier run stayed grid-fed
+# for ~10 min at the 20 % floor because only the min_runtime dwell timed the
+# OFF and no executor path checked SOC/inverter state.
+# ---------------------------------------------------------------------------
+
+
+async def test_floor_guard_forces_off_despite_min_runtime(hass):
+    """G4: at the inverter floor a RUNNING load is forced off immediately —
+    dwell-exempt — even while the plan still wants it on (inverts the
+    plan-flap min_runtime hold for the guard case)."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(
+        hass, calls, energy_limited=False, min_runtime_min=30, min_off_min=30
+    )
+    hass.states.async_set(PLUG, "off")
+    hass.states.async_set(ENABLE, "off")
+    now = dt_util.utcnow()
+    durations = (1.0, 1.0, 1.0)
+    active = SimpleNamespace(load_plans=[_night_plan(sub_id, 3)])
+
+    await coordinator._apply_load_switching(active, now, durations)
+    await hass.async_block_till_done()
+    assert coordinator._load_charging_active[sub_id] is True
+
+    # SOC hits the 20 % floor 10 min in (far below min_runtime 30): the
+    # guard trips and the SAME still-active plan must now force the OFF.
+    config = coordinator.build_system_config()
+    assert coordinator._update_floor_guard(20.0, config) is True
+    calls.clear()
+    await coordinator._apply_load_switching(
+        active, now + timedelta(minutes=10), durations
+    )
+    await hass.async_block_till_done()
+    assert ("turn_off", PLUG) in calls or ("turn_off", ENABLE) in calls
+    assert coordinator._load_charging_active[sub_id] is False
+    coordinator._cancel_off_timer(sub_id)
+
+
+async def test_floor_guard_blocks_switch_on(hass):
+    """G4: while the guard is active no load is switched ON, however active
+    the plan is."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, energy_limited=False)
+    hass.states.async_set(PLUG, "off")
+    hass.states.async_set(ENABLE, "off")
+    config = coordinator.build_system_config()
+    assert coordinator._update_floor_guard(19.0, config) is True
+
+    await coordinator._apply_load_switching(
+        SimpleNamespace(load_plans=[_night_plan(sub_id, 3)]),
+        dt_util.utcnow(),
+        (1.0, 1.0, 1.0),
+    )
+    await hass.async_block_till_done()
+    assert calls == []
+    assert coordinator._load_charging_active.get(sub_id, False) is False
+
+
+async def test_floor_guard_latch_and_release_hysteresis(hass):
+    """G4 latch: trips AT the floor (20), holds through the release band
+    (20.5), releases only at floor + hysteresis (21); once released it does
+    not re-trip above the floor."""
+    calls: list[tuple[str, str]] = []
+    coordinator, _sub_id, _data = await _setup(hass, calls)
+    config = coordinator.build_system_config()
+    coordinator._inverter_recommendation = True
+    coordinator._floor_guard_active = False  # released state
+
+    assert coordinator._update_floor_guard(20.0, config) is True  # trip
+    assert coordinator._update_floor_guard(20.5, config) is True  # latched
+    assert coordinator._update_floor_guard(21.0, config) is False  # release
+    assert coordinator._update_floor_guard(20.5, config) is False  # no re-trip
+    assert coordinator._update_floor_guard(20.0, config) is True  # trip again
+
+
+async def test_floor_guard_restart_inside_band_starts_latched(hass):
+    """G4: after a restart (member None) a SOC inside the release band counts
+    as latched — conservative until the SOC provably recovered."""
+    calls: list[tuple[str, str]] = []
+    coordinator, _sub_id, _data = await _setup(hass, calls)
+    config = coordinator.build_system_config()
+    coordinator._inverter_recommendation = True
+    coordinator._floor_guard_active = None  # simulate the fresh-restart state
+    assert coordinator._update_floor_guard(20.5, config) is True
+
+
+async def test_floor_guard_trips_on_inverter_recommendation_off(hass):
+    """G4: an inverter-recommendation OFF trips the guard at ANY SOC (a
+    T*-driven shutdown routes the house to grid); recommendation back on
+    with healthy SOC releases it."""
+    calls: list[tuple[str, str]] = []
+    coordinator, _sub_id, _data = await _setup(hass, calls)
+    config = coordinator.build_system_config()
+    coordinator._floor_guard_active = False
+    coordinator._inverter_recommendation = False
+    assert coordinator._update_floor_guard(50.0, config) is True
+    coordinator._inverter_recommendation = True
+    assert coordinator._update_floor_guard(50.0, config) is False
+
+
+async def test_floor_guard_drops_queued_switch_on(hass):
+    """G4 in-flight race: an ON action queued BEFORE the trip must not fire —
+    _execute_load_switching re-checks the guard per action and drops it."""
+    from homeassistant.util import dt as dt_util
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, data = await _setup(hass, calls, energy_limited=False)
+    hass.states.async_set(PLUG, "off")
+    hass.states.async_set(ENABLE, "off")
+    coordinator._floor_guard_active = True  # tripped after the action was queued
+    await coordinator._execute_load_switching(
+        [(sub_id, data, True, False, 1.0)], dt_util.utcnow()
+    )
+    await hass.async_block_till_done()
+    assert not any(c[0] == "turn_on" for c in calls)
+    assert coordinator._load_charging_active.get(sub_id, False) is False
+
+
+async def test_floor_guard_off_stamps_dwell_min_off_gates_re_on(hass):
+    """G4: the guard-forced OFF stamps the dwell, so after the guard releases
+    a re-ON stays blocked for min_off and succeeds afterwards (compressor
+    protection survives the safety off)."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(
+        hass, calls, energy_limited=False, min_runtime_min=30, min_off_min=15
+    )
+    hass.states.async_set(PLUG, "off")
+    hass.states.async_set(ENABLE, "off")
+    now = dt_util.utcnow()
+    durations = (1.0, 1.0, 1.0)
+    active = SimpleNamespace(load_plans=[_night_plan(sub_id, 3)])
+
+    await coordinator._apply_load_switching(active, now, durations)
+    await hass.async_block_till_done()
+    assert coordinator._load_charging_active[sub_id] is True
+
+    # Guard trips 5 min in: forced OFF (dwell-exempt) stamps the dwell.
+    config = coordinator.build_system_config()
+    assert coordinator._update_floor_guard(20.0, config) is True
+    off_at = now + timedelta(minutes=5)
+    await coordinator._apply_load_switching(active, off_at, durations)
+    await hass.async_block_till_done()
+    assert coordinator._load_charging_active[sub_id] is False
+
+    # Guard releases; plan still active: min_off (15) blocks the re-ON ...
+    assert coordinator._update_floor_guard(25.0, config) is False
+    calls.clear()
+    await coordinator._apply_load_switching(
+        active, off_at + timedelta(minutes=10), durations
+    )
+    await hass.async_block_till_done()
+    assert not any(c[0] == "turn_on" for c in calls)
+    # ... and admits it once min_off has elapsed.
+    await coordinator._apply_load_switching(
+        active, off_at + timedelta(minutes=16), durations
+    )
+    await hass.async_block_till_done()
+    assert any(c[0] == "turn_on" for c in calls)
+    coordinator._cancel_off_timer(sub_id)
+
+
+async def test_floor_guard_caps_published_active(hass):
+    """G4: the published per-load `active` (which operator automations and
+    recommendation-only loads follow) reads False while the guard is active,
+    for an otherwise fully active plan."""
+    from homeassistant.util import dt as dt_util
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls)
+    plan = _night_plan(sub_id, 3)
+    now = dt_util.utcnow()
+    coordinator._floor_guard_active = False
+    assert coordinator._effective_load_active(plan, now) is True
+    coordinator._floor_guard_active = True
+    assert coordinator._effective_load_active(plan, now) is False
+
+
+# ---------------------------------------------------------------------------
 # F-PLANNER-HONESTY F1: learned planning power (docs/F-PLANNER-HONESTY.md
 # R2/R3/R6). The run-max of the accepted-sample EMA survives the run (and
 # restarts), so an OFF load is planned at its real power instead of the


### PR DESCRIPTION
**Incident** 2026-07-18 06:20–06:30: a planner-booked dehumidifier run stayed ON for ~10 min at the 20 % inverter-cutoff SOC — the real inverter had shut down, so the 432 W load ran on GRID. Root cause: the plan deactivated at 06:20, but the min_runtime ON→OFF dwell held the switch until 06:30, and **no executor path checked SOC or inverter state** (the recommendation's ±1 % hysteresis kept it ON at exactly 20.0).

**Binding operator rule** (2026-07-18): "Wenn der Inverter aus ist oder der SOC 20 % erreicht, dürfen Zusatzlasten nicht mehr angesteuert werden."

## What changed (executor only — planner untouched, goldens identical)
- **G4 floor guard** (`_update_floor_guard`, every cycle): trips at `soc <= inverter_min_soc_percent` OR inverter recommendation off. Whole-guard latch; release strictly above the floor at `floor + hysteresis_percent` (disjoint from trip even at hysteresis 0); restart inside the band starts latched.
- **Enforcement:** running controlled loads forced OFF **dwell-exempt** (min_off still gates the re-on); no switch-ONs; queued ONs are dropped inside `_execute_load_switching` (in-flight race) with a catch-up refresh; published per-load `active` reads False (operator automations and recommendation-only loads stop), the appliance start-window advisory reads False, runtime accrual's plan-fallback pauses, and the power warning treats loads as inactive (no 0 W "full tank" false positive during an episode).
- **Reaction time:** the ~5 s debounced SOC refresh instead of up to a full dwell (the incident's 10-min gap).
- Diagnostics: `floor_guard_active` in coordinator data + as attribute on the inverter-recommendation sensor. Spec: `docs/F-EXECUTOR-GUARDS.md` G4 + `docs/LOAD_CONTROL.md` §11.

## Verification
- 10 new tests: force-off despite min_runtime, ON blocked, latch trip/hold/release incl. hysteresis-0 disjointness, recommendation-off trip, restart-in-band, published-active cap, queued-ON drop, min_off-after-guard-off, end-to-end refresh at floor SOC, load-bearing appliance-advisory baseline (True → False under guard).
- Full WSL HA suite green; ruff clean; versions synced 0.13.1; goldens untouched (no core change).
- Adversarial multi-agent review (19 agents): 14 confirmed findings — 1 medium in-flight race, 1 hysteresis-0 latch hole, a G3→G4 naming collision, doc/test gaps — **all fixed or explicitly documented** before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)