### PR TITLE
Release v0.14.0: robust power learning + seamless runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-18
+
+### Fixed
+- **818 W phantom planning power (F-ROBUST-POWER).** At the 06:21 inverter
+  cutoff a 1711 W compressor-restart transient (held ~60 s by the measuring
+  plug) was blended into the power EMA (0.3·1711 + 0.7·433 ≈ 818) and frozen
+  by the run-max rule — a 426 W dehumidifier was planned at 818 W all
+  morning, squeezing the fossibot into 30-min scraps. The EMA/run-max
+  learner is replaced by a robust TIME-WEIGHTED MEDIAN over the run's last
+  ~30 min: short spikes/dips (inrush, defrost, transfer transients) can
+  never move it, sustained changes are adopted (~15 min, or ~10 min via the
+  stable fast-adopt window — operator-changed charge rates included), and
+  the first 5 min of a run never learn (inrush kill). No nominal clamp
+  (levels above nominal are legitimate); estimates above 3× nominal log a
+  change-gated warning. Old persisted values self-heal on the first run.
+- **50 % duty-cycling at quantum boundaries (F-SEAMLESS-RUNS).** The
+  executor force-offed at every booked-quantum end while the replan re-booked
+  seconds later, and min_off then enforced a pointless 30-min pause (relay
+  cycles, compressor restarts — which also fed the 818 W incident). Per the
+  operator's min_off model ("mindestens die konfigurierte Zeit aus, wenn
+  ABSICHTLICH deaktiviert"), an expired deadline with a freshly re-booked
+  contiguous run now EXTENDS seamlessly: no OFF, no dwell stamp. min_off
+  arms only on deliberate stops (surplus gone, target reached, floor guard,
+  no re-booking). Energy-limited loads extend only while the G2 stale-SOC
+  guard can supervise them — everything G2-unsupervisable keeps the R7/R8
+  duty-cycle cap.
+
+### Changed
+- Runs shorter than ~5 min no longer produce or learn a measured power
+  (warm-up). Appliance planning is explicitly unaffected by learning — it
+  always uses the declared run energy/duration (documented clarification).
+
 ## [0.13.1] - 2026-07-18
 
 ### Fixed

--- a/custom_components/battery_manager/coordinator.py
+++ b/custom_components/battery_manager/coordinator.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import math
+from collections import deque
 from dataclasses import replace
 from datetime import datetime, timedelta
 from typing import Any
@@ -133,6 +134,7 @@ from .core import (
     aggregate_hours,
     build_slots,
     plan,
+    power_learning,
     profile_value,
     quantile_band_slots,
     slot_starts,
@@ -140,8 +142,6 @@ from .core import (
 from .history_profile import ProfileLearner
 
 _LOGGER = logging.getLogger(__name__)
-
-_POWER_EMA_ALPHA = 0.3
 
 
 def _series_source(series: tuple[float | None, ...] | None, index: int) -> str:
@@ -311,15 +311,19 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # check in _get_appliance_runs, so a run that finished during downtime
         # cannot pin a genuinely-new run at 0 remaining.
         self._appliance_started_restored: set[str] = set()
-        self._load_power_ema: dict[str, float] = {}
-        # Learned planning power (F-PLANNER-HONESTY R2): per load the run-max
-        # of the accepted-sample EMA — run-max so an end-of-charge taper cannot
-        # erode it, EMA so a spike cannot inflate it, and only samples past the
-        # v0.6.2 standby bar feed it (the single gate; standby poisoning stays
-        # impossible). `_load_run_power_max` tracks the CURRENT run (same
-        # lifecycle as `_load_power_ema`); `_load_learned_power_w` is the
-        # persisted last-run-wins store an OFF load plans with.
-        self._load_run_power_max: dict[str, float] = {}
+        # Robust planning-power estimation (docs/F-ROBUST-POWER.md): per load
+        # a rolling buffer of ACCEPTED (timestamp, watts) samples — only
+        # readings past the v0.6.2 standby bar while the load runs at BM's
+        # request (the single gate; standby poisoning stays impossible). The
+        # time-weighted windowed median in core/power_learning.py replaces
+        # the former EMA/run-max pair after the 2026-07-18 818 W incident (a
+        # 60 s compressor-restart transient was EMA-blended and frozen by the
+        # run-max). Buffer lifecycle = the run; `_load_learned_power_w` is
+        # the persisted write-through of the estimate an OFF load plans with.
+        self._load_power_samples: dict[str, deque[tuple[datetime, float]]] = {}
+        # Change-gated 3x-nominal estimate warning (sensor-lie observability;
+        # deliberately no clamp — levels above nominal can be legitimate).
+        self._load_power_overrun_warned: set[str] = set()
         self._load_learned_power_w: dict[str, float] = {}
         # Stale-SOC guard (F-EXECUTOR-GUARDS G2): evidence tuple (frozen value,
         # since) while actively charging above the standby bar, and the latch
@@ -403,9 +407,10 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             }
             # The switch dwell survives restarts: a wiped timestamp allowed
             # switching right after boot (co-factor of the 2026-07-05
-            # night-charge incident). The power EMA is deliberately NOT
-            # persisted — a taper-decayed value (last reading of a finished
-            # charge) would otherwise become permanent planning power.
+            # night-charge incident). The live power-sample buffer is
+            # deliberately NOT persisted — a stale window (last readings of a
+            # finished charge) would otherwise serve as fresh measurement;
+            # the LEARNED write-through value below carries across restarts.
             for k, v in data.get("last_load_switch", {}).items():
                 ts = dt_util.parse_datetime(v) if isinstance(v, str) else None
                 if ts is not None:
@@ -500,10 +505,11 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # After a restart the first tick just re-arms the cursor (losing at
             # most the last sub-cycle partial, which is bounded and unobservable).
             "load_runtime_seconds": dict(self._load_runtime_seconds),
-            # F-PLANNER-HONESTY R3: the learned planning power (run-max of the
-            # accepted-sample EMA) survives restarts — unlike the live EMA
-            # (deliberately volatile, see async_load_persistent_state), the
-            # learned value is taper-proof by construction.
+            # F-PLANNER-HONESTY R3 / F-ROBUST-POWER: the learned planning
+            # power (write-through of the robust windowed estimate) survives
+            # restarts — unlike the live sample buffer (deliberately
+            # volatile, see async_load_persistent_state); spike-proof by the
+            # estimator's median + warm-up construction.
             "load_learned_power": dict(self._load_learned_power_w),
             # F-SUBHOUR H1: persist the appliance run start so a restart mid-run
             # does not re-latch at `now` and re-inject the full run energy.
@@ -1464,7 +1470,34 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return True
         return False
 
-    def _get_load_states(self) -> tuple[SurplusLoadState, ...]:
+    def _warn_estimate_overrun(
+        self, subentry_id: str, title: str, learned: float, data
+    ) -> None:
+        """Sensor-lie observability (F-ROBUST-POWER): warn ONCE per run when
+        the robust estimate exceeds 3x the configured nominal power. The
+        median cannot detect a plausible frozen sensor value, and levels
+        above nominal are legitimate (operator-raised charge rates), so this
+        deliberately observes instead of clamping."""
+        nominal = float(data[CONF_LOAD_POWER_W])
+        if learned > 3.0 * nominal:
+            if subentry_id not in self._load_power_overrun_warned:
+                self._load_power_overrun_warned.add(subentry_id)
+                _LOGGER.warning(
+                    "Load %s: robust power estimate %.0f W exceeds 3x the"
+                    " configured %.0f W — check the power sensor (frozen/"
+                    "cached value?) or the configured nominal power",
+                    title,
+                    learned,
+                    nominal,
+                )
+        else:
+            self._load_power_overrun_warned.discard(subentry_id)
+
+    def _get_load_states(
+        self, now: datetime | None = None
+    ) -> tuple[SurplusLoadState, ...]:
+        if now is None:
+            now = dt_util.utcnow()
         states = []
         for subentry_id, subentry in self.entry.subentries.items():
             if subentry.subentry_type != SUBENTRY_TYPE_LOAD:
@@ -1533,43 +1566,52 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     10.0, STANDBY_FRACTION * float(data[CONF_LOAD_POWER_W])
                 )
                 bm_active = self._bm_load_active(subentry_id)
+                buf = self._load_power_samples.get(subentry_id)
                 if raw is not None and raw >= min_sample_w and bm_active:
-                    # R2a: the EMA seeds VERBATIM from the run's first accepted
-                    # sample (previous = raw), so only samples with a PRIOR
-                    # EMA entry may feed the learned run-max — a single
-                    # start-up spike must not be learned permanently.
-                    ema_seeded = subentry_id in self._load_power_ema
-                    previous = self._load_power_ema.get(subentry_id, raw)
-                    measured = (
-                        _POWER_EMA_ALPHA * raw + (1 - _POWER_EMA_ALPHA) * previous
-                    )
-                    self._load_power_ema[subentry_id] = measured
-                    # F-PLANNER-HONESTY R2: learn the run-max of the accepted-
-                    # sample EMA; the store always holds the current run's max
-                    # once it has enough accepted samples (last run wins), so
-                    # an OFF load later plans at its real power, not nominal.
-                    if ema_seeded:
-                        run_max = max(
-                            self._load_run_power_max.get(subentry_id, measured),
-                            measured,
+                    # F-ROBUST-POWER: append the accepted sample and serve the
+                    # time-weighted windowed median. During warm-up (< 5 min
+                    # accepted coverage) the estimate is None — start-up
+                    # inrush can never be served or learned (supersedes the
+                    # F-PLANNER-HONESTY R2a seed rule); planning falls back
+                    # to learned/nominal via planning_power_w.
+                    if buf is None:
+                        buf = self._load_power_samples[subentry_id] = deque(
+                            maxlen=power_learning.MAX_SAMPLES
                         )
-                        self._load_run_power_max[subentry_id] = run_max
-                        if self._load_learned_power_w.get(subentry_id) != run_max:
-                            self._load_learned_power_w[subentry_id] = run_max
+                    buf.append((now, raw))
+                    est = power_learning.robust_power_estimate(buf, now)
+                    measured = est.watts
+                    if measured is not None:
+                        # Write-through: the persisted learned value always
+                        # holds the run's CURRENT robust estimate ("last
+                        # stable estimate wins"), so an OFF load later plans
+                        # at its real level — sustained changes included,
+                        # spikes excluded by construction. Persist only on
+                        # >= 1 W movement: sub-watt jitter would otherwise
+                        # re-trigger the delayed save every cycle (~dozens
+                        # of .storage writes per run-hour, review finding).
+                        learned = round(measured, 1)
+                        prev_learned = self._load_learned_power_w.get(subentry_id)
+                        if prev_learned is None or abs(learned - prev_learned) >= 1.0:
+                            self._load_learned_power_w[subentry_id] = learned
                             self._save_persistent_state()
-                elif subentry_id in self._load_power_ema:
+                        self._warn_estimate_overrun(
+                            subentry_id, subentry.title, learned, data
+                        )
+                elif buf is not None:
                     if bm_active:
-                        # Mid-run feedback gap (v0.5.1): keep planning
-                        # with the last smoothed value.
-                        measured = self._load_power_ema[subentry_id]
+                        # Mid-run feedback gap (v0.5.1 semantics): keep
+                        # serving the buffer's estimate; the last sample
+                        # covers at most GAP_CAP_S, so a long outage decays
+                        # into warm-up (None) rather than a stale value.
+                        measured = power_learning.robust_power_estimate(buf, now).watts
                     else:
                         # Run over (or the device is being used outside the
-                        # manager's plan): a taper/standby/foreign value
+                        # manager's plan): a taper/standby/foreign window
                         # must not stick as "measured" planning power. The
-                        # run-max tracker ends with the run; the LEARNED value
-                        # keeps serving (that is its point, R1/R2).
-                        del self._load_power_ema[subentry_id]
-                        self._load_run_power_max.pop(subentry_id, None)
+                        # LEARNED write-through value keeps serving.
+                        del self._load_power_samples[subentry_id]
+                        self._load_power_overrun_warned.discard(subentry_id)
             # F-EXECUTOR-GUARDS G2 (R6): a stale-latched load is held
             # unavailable — the planner stops re-booking against the frozen
             # `remaining`, and the plan-driven OFF runs through the normal
@@ -1801,7 +1843,7 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"No valid input data available ({missing})")
 
         config = self.build_system_config()
-        load_states = self._get_load_states()
+        load_states = self._get_load_states(now)
         appliance_runs = self._get_appliance_runs(now)
         ac_series, dc_series, band, quantiles_active, profile_diag = (
             self._learned_series(now, config, len(forecasts))
@@ -2890,6 +2932,36 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return True
         return self._entity_tristate(enable)
 
+    def _seamless_extension_ok(self, load_id: str, data) -> bool:
+        """F-SEAMLESS-RUNS: may an expired run deadline be extended instead
+        of force-switching OFF?
+
+        Non-energy-limited loads: always — the deadline is pure quantum
+        bookkeeping for them. Energy-limited loads: only while the G2
+        stale-SOC guard CAN supervise the load RIGHT NOW — control switch
+        configured AND the SOC and power-feedback entities currently
+        READABLE (not merely configured: during a sensor outage G2 gathers
+        no evidence, so an extension would reopen the unbounded-charge
+        hole; review finding 2026-07-18) AND not stale-latched. Anything
+        G2 cannot supervise keeps the F-RESIDUAL-TOPUP R7/R8 duty-cycle
+        cap (recommendation-only energy-limited loads included), because
+        for those the cap is the ONLY defence against a stale `remaining`
+        stretching a small top-up into an unbounded charge."""
+        if not data.get(CONF_LOAD_ENERGY_LIMITED):
+            return True
+        if not data.get(CONF_LOAD_CONTROL_SWITCH):
+            return False
+        if load_id in self._load_soc_stale:
+            return False
+        soc_entity = data.get(CONF_LOAD_SOC_ENTITY)
+        power_entity = data.get(CONF_LOAD_POWER_ENTITY)
+        if not soc_entity or not power_entity:
+            return False
+        return (
+            self._read_float(soc_entity) is not None
+            and self._read_float(power_entity) is not None
+        )
+
     def _maintain_recommendation_deadline(
         self, load_id, data, plan, now: datetime, slot_durations
     ) -> None:
@@ -2901,13 +2973,20 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         run's start to `run_start + max(min_runtime, run)` and off for the rest. A
         later export window (plan cycles inactive->active) re-anchors.
 
-        FIX-5: while the plan stays CONTINUOUSLY active (e.g. a night pre-drain
-        glued to the following day's block never lets it cycle inactive), the
-        frozen deadline used to wedge the published `active` False from expiry
-        until the whole block ended (hours). Once `now >= deadline + min_off`
-        (min_off falls back to min_runtime) we RE-ANCHOR a fresh run window —
-        mirroring a controlled load's force-off -> min_off dwell -> re-on cycle —
-        so the sensor duty-cycles instead of staying wedged off."""
+        F-SEAMLESS-RUNS: when the plan is STILL active at the expired
+        deadline and the load is extension-eligible, the window re-anchors
+        IMMEDIATELY (without the min_runtime floor — it was already served)
+        so the published `active` never dips at a quantum boundary — the
+        operator's automation keeps the device running seamlessly.
+
+        FIX-5 (fallback for extension-INELIGIBLE loads, i.e. energy-limited
+        recommendation-only loads keeping the F-RESIDUAL-TOPUP R9 cap):
+        while the plan stays CONTINUOUSLY active, the frozen deadline used
+        to wedge the published `active` False from expiry until the whole
+        block ended (hours). Once `now >= deadline + min_off` (min_off
+        falls back to min_runtime) we RE-ANCHOR a fresh run window —
+        mirroring a controlled load's force-off -> min_off dwell -> re-on
+        cycle — so the sensor duty-cycles instead of staying wedged off."""
         active = bool(plan and plan.active_now)
         if not active:
             if load_id in self._load_run_deadline:
@@ -2916,24 +2995,28 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
         min_runtime = int(data.get(CONF_LOAD_MIN_RUNTIME_MIN, 30))
 
-        def _anchor() -> None:
+        def _anchor(floor_min: int) -> None:
             off_min = max(
-                min_runtime, round(plan.active_run_hours(slot_durations) * 60.0)
+                floor_min, round(plan.active_run_hours(slot_durations) * 60.0)
             )
-            off_at = now + timedelta(minutes=off_min)
+            off_at = now + timedelta(minutes=max(1, off_min))
             self._load_run_deadline[load_id] = off_at
             self._arm_off_timer(load_id, off_at)
 
         deadline = self._load_run_deadline.get(load_id)
         if deadline is None:
-            _anchor()  # OFF->ON edge: freeze the first run window
+            _anchor(min_runtime)  # OFF->ON edge: freeze the first run window
             return
-        # Still active past the deadline: re-anchor once the min_off dwell (since
-        # the deadline) has elapsed, so a continuously-active block does not wedge
-        # the published `active` off for the rest of the block.
+        if now >= deadline and self._seamless_extension_ok(load_id, data):
+            # F-SEAMLESS-RUNS: still booked at the boundary — re-anchor now,
+            # no min_runtime floor (already served), `active` never dips.
+            _anchor(1)
+            return
+        # Extension-ineligible fallback (FIX-5): re-anchor once the min_off
+        # dwell (since the deadline) has elapsed.
         min_off = int(data.get(CONF_LOAD_MIN_OFF_MIN, min_runtime))
         if now >= deadline + timedelta(minutes=min_off):
-            _anchor()
+            _anchor(min_runtime)
 
     def _update_floor_guard(self, soc: float, config: SystemConfig) -> bool:
         """G4 floor guard (F-EXECUTOR-GUARDS, operator rule 2026-07-18):
@@ -3044,6 +3127,34 @@ class BatteryManagerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # G4: grid-fed operation is forbidden — force OFF, block ON.
                 desired = False
             elif current and deadline is not None and now >= deadline:
+                # F-SEAMLESS-RUNS: THIS refresh's plan was recomputed with
+                # fresh remaining/SOC data BEFORE switching runs. If it
+                # re-booked a contiguous run starting now and the load is
+                # extension-eligible, continue seamlessly — no OFF/ON relay
+                # cycle, no compressor restart, no min_off pause. min_off is
+                # thereby armed only by DELIBERATE deactivations (plan-off,
+                # target stop, floor guard, deadline without re-booking) —
+                # the operator's min_off semantics (2026-07-18).
+                run_h = plan.active_run_hours(slot_durations) if plan else 0.0
+                if (
+                    active_now
+                    and run_h > 0.0
+                    and self._seamless_extension_ok(subentry_id, data)
+                ):
+                    off_at = now + timedelta(minutes=max(1, round(run_h * 60.0)))
+                    self._load_run_deadline[subentry_id] = off_at
+                    self._arm_off_timer(subentry_id, off_at)
+                    # Persist the extended deadline in THIS cycle so a
+                    # restart right after the boundary restores it.
+                    self._save_persistent_state()
+                    _LOGGER.info(
+                        "Load %s: plan re-booked %.2f h at the run deadline —"
+                        " extending seamlessly to %s",
+                        subentry.title,
+                        run_h,
+                        off_at,
+                    )
+                    continue  # no OFF, no dwell stamp
                 desired = False
             else:
                 desired = active_now

--- a/custom_components/battery_manager/core/model.py
+++ b/custom_components/battery_manager/core/model.py
@@ -101,10 +101,13 @@ class SurplusLoadState:
     load_id: str
     available: bool = True  # False: unplugged/unavailable -> never scheduled
     soc_percent: float | None = None  # for energy_limited loads
-    measured_power_w: float | None = None  # smoothed feedback power
-    # Run-max of the accepted-sample EMA from past runs (F-PLANNER-HONESTY R1):
-    # honest planning power for an OFF load whose configured nominal is wrong
-    # (F2400-B: 300 W configured vs ~505 W real — every gate ~40 % under).
+    # Robust windowed estimate while the load runs at BM's request
+    # (F-ROBUST-POWER; None during warm-up and while off).
+    measured_power_w: float | None = None
+    # Last run's robust estimate, persisted (F-PLANNER-HONESTY R1 intent,
+    # estimator per F-ROBUST-POWER): honest planning power for an OFF load
+    # whose configured nominal is wrong (F2400-B: 300 W configured vs ~505 W
+    # real — every gate ~40 % under).
     learned_power_w: float | None = None
 
     def remaining_energy_wh(self, load: SurplusLoad) -> float | None:

--- a/custom_components/battery_manager/core/power_learning.py
+++ b/custom_components/battery_manager/core/power_learning.py
@@ -1,0 +1,143 @@
+"""Robust per-load planning-power estimation (docs/F-ROBUST-POWER.md).
+
+Operator spec (2026-07-18, binding): the planning power of a surplus load is
+a robust average over the recent run window. SHORT dips and spikes — defrost
+pauses, compressor inrush, inverter-transfer transients — must ALWAYS be
+ignored; SUSTAINED level changes must be adopted (a durably low draw is
+real), and when the normal level returns for a longer stretch (~10 min) it
+must be re-learned quickly. The estimator must generalise across load types
+(operator-changed powerstation charge rates, battery-side throttling), so
+legitimate levels ABOVE the configured nominal power are allowed — there is
+deliberately no nominal clamp here.
+
+Incident that forced this design: at the 2026-07-18 06:21 inverter cutoff
+the dehumidifier compressor's restart transient (1711 W, held ~60 s by the
+measuring plug) was blended into the previous EMA (0.3·1711 + 0.7·433 ≈ 818)
+and the run-max rule froze and persisted 818 W for a 426 W device.
+
+Mechanics: samples are TIME-WEIGHTED — each accepted sample covers the span
+until the next one (capped at GAP_CAP_S), clipped to the rolling window. The
+estimate is the weighted median over WINDOW_S: a level occupying less than
+half the covered time (a spike, a short defrost dip) cannot move it, while a
+sustained level becomes the majority after ~WINDOW_S/2. A FAST-ADOPT path
+covers the operator's "10 minutes of restored normal load" rule: when the
+last FAST_WINDOW_S are internally stable (P10/P90 within STABLE_BAND of
+their median) and that sub-median deviates by more than FAST_DEVIATION from
+the slow median, the sub-median wins immediately. Below WARMUP_COVERAGE_S of
+accepted coverage no estimate is produced at all — start-up inrush can never
+be learned (supersedes the F-PLANNER-HONESTY R2a seed rule).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from .load_profile import weighted_quantile
+
+WINDOW_S = 1800.0  # robust window (operator sketch: ~30 min)
+FAST_WINDOW_S = 600.0  # fast re-learn sub-window (operator: ~10 min)
+STABLE_BAND = 0.20  # P10/P90 within ±20 % of the sub-median = "stable"
+FAST_DEVIATION = 0.20  # sub-median must deviate >20 % from the slow median
+WARMUP_COVERAGE_S = 300.0  # no estimate below 5 min of accepted coverage
+GAP_CAP_S = 300.0  # one sample covers at most 5 min of silence
+DOMINANCE_MAX = 0.8  # no single sample may carry >80 % of a window's weight
+MAX_SAMPLES = 720  # deque bound for callers (1 h at 5 s event cadence)
+
+
+@dataclass(frozen=True)
+class PowerEstimate:
+    """Result of `robust_power_estimate`.
+
+    `watts` is None while the run has not yet accumulated
+    WARMUP_COVERAGE_S of accepted samples (warm-up: nothing is served or
+    learned). `coverage_s` is the time-weighted accepted coverage inside
+    the window; `fast_adopted` marks an estimate taken from the stable
+    FAST_WINDOW_S sub-window instead of the slow median.
+    """
+
+    watts: float | None
+    coverage_s: float
+    fast_adopted: bool = False
+
+
+def _clipped_weights(
+    samples: Sequence[tuple[datetime, float]],
+    now: datetime,
+    window_s: float,
+) -> tuple[list[float], list[float]]:
+    """Per-sample (value, covered-seconds) pairs clipped to the window.
+
+    Sample i covers [t_i, min(t_{i+1}, t_i + GAP_CAP_S)); the last sample
+    covers up to min(now, t_n + GAP_CAP_S). Each span is then clipped to
+    [now - window_s, now]; zero-weight samples are dropped.
+    """
+    window_start = now.timestamp() - window_s
+    now_ts = now.timestamp()
+    values: list[float] = []
+    weights: list[float] = []
+    for i, (ts, watts) in enumerate(samples):
+        start = ts.timestamp()
+        if i + 1 < len(samples):
+            end = min(samples[i + 1][0].timestamp(), start + GAP_CAP_S)
+        else:
+            end = min(now_ts, start + GAP_CAP_S)
+        lo = max(start, window_start)
+        hi = min(end, now_ts)
+        weight = hi - lo
+        if weight <= 0.0:
+            continue
+        values.append(watts)
+        weights.append(weight)
+    return values, weights
+
+
+def robust_power_estimate(
+    samples: Sequence[tuple[datetime, float]], now: datetime
+) -> PowerEstimate:
+    """Robust time-weighted planning-power estimate over the run window.
+
+    `samples` are (timestamp, watts) pairs of ACCEPTED readings (the caller
+    applies the standby bar and the runs-at-BM's-request gate), in
+    chronological order.
+    """
+    values, weights = _clipped_weights(samples, now, WINDOW_S)
+    coverage = sum(weights)
+    # Warm-up needs enough covered time AND a window not dominated by one
+    # sample: with GAP_CAP_S == WARMUP_COVERAGE_S a SINGLE sample followed
+    # by silence reaches exactly the coverage bar, and at poll cadence the
+    # newest sample carries ~zero weight — a lone start-up/transfer
+    # transient could become the estimate and be learned (the incident
+    # class this module exists to prevent; review finding 2026-07-18).
+    # The dominance bar makes the median provably multi-sample-backed.
+    if (
+        coverage < WARMUP_COVERAGE_S
+        or len(values) < 2
+        or max(weights) > DOMINANCE_MAX * coverage
+    ):
+        return PowerEstimate(None, coverage)
+    slow = weighted_quantile(values, weights, 0.5)
+
+    fast_values, fast_weights = _clipped_weights(samples, now, FAST_WINDOW_S)
+    fast_coverage = sum(fast_weights)
+    # The stability test is vacuous when one sample dominates the window
+    # (P10 == P90 == it), e.g. one accepted glitch held by GAP_CAP through
+    # a sensor outage — apply the same dominance bar here.
+    if (
+        fast_coverage >= WARMUP_COVERAGE_S
+        and len(fast_values) >= 2
+        and max(fast_weights) <= DOMINANCE_MAX * fast_coverage
+    ):
+        fast = weighted_quantile(fast_values, fast_weights, 0.5)
+        p10 = weighted_quantile(fast_values, fast_weights, 0.10)
+        p90 = weighted_quantile(fast_values, fast_weights, 0.90)
+        stable = (
+            fast > 0.0
+            and p10 >= (1.0 - STABLE_BAND) * fast
+            and p90 <= (1.0 + STABLE_BAND) * fast
+        )
+        deviates = slow <= 0.0 or abs(fast - slow) > FAST_DEVIATION * slow
+        if stable and deviates:
+            return PowerEstimate(fast, coverage, fast_adopted=True)
+    return PowerEstimate(slow, coverage)

--- a/custom_components/battery_manager/manifest.json
+++ b/custom_components/battery_manager/manifest.json
@@ -18,5 +18,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danielr0815/battery-manager-ha/issues",
   "requirements": [],
-  "version": "0.13.1"
+  "version": "0.14.0"
 }

--- a/docs/ALGORITHM.md
+++ b/docs/ALGORITHM.md
@@ -168,12 +168,14 @@ candidates).
   "Setze alles um", 2026-07-10):** Three refinements
   (docs/F-PLANNER-HONESTY.md, resolves the open decision O1 of
   F-RESIDUAL-TOPUP):
-  1. **Learned planning power:** the coordinator learns per load the run-max
-     of the accepted-sample EMA (run-max so an end-of-charge taper cannot
-     erode it, EMA so a spike cannot inflate it, standby-barred samples never
-     feed it) and persists it, so an OFF load is planned at its real power
-     (F2400-B: ~505 W) instead of the configured nominal (300 W). Precedence:
-     live measured > learned > nominal.
+  1. **Learned planning power:** the coordinator learns per load a robust
+     estimate of the real draw (since v0.14.0 the time-weighted windowed
+     MEDIAN of accepted samples, docs/F-ROBUST-POWER.md — spikes/dips are
+     majority-immune, 5-min warm-up; historically the run-max-of-EMA, which
+     the 2026-07-18 818 W transient incident retired) and persists it, so an
+     OFF load is planned at its real power (F2400-B: ~505 W) instead of the
+     configured nominal (300 W). Precedence: live measured > learned >
+     nominal (unchanged).
   2. **Pass 1 is load-outer** in config order (strict priority: a load books
      its complete pass-1 allocation before the next load sees the horizon)
      with per-class slot direction — **day-bounded latest-first for

--- a/docs/CONSUMPTION_FORECAST.md
+++ b/docs/CONSUMPTION_FORECAST.md
@@ -165,7 +165,7 @@ OR at least one `*_balance_in_entities` entity is set. No separate toggle
 counter → validation error in the flow.
 
 **Deliberately hardcoded** (documented constants, consistent with
-`_POWER_EMA_ALPHA`): learning time 03:00 local, `min_samples` = 10 per bin
+the former `_POWER_EMA_ALPHA`, retired in v0.14.0 by F-ROBUST-POWER): learning time 03:00 local, `min_samples` = 10 per bin
 (absence: 5), plausibility clamps (AC 3 000 W, DC 1 000 W per hourly mean),
 change rate limit ±20 %/night, median as the aggregate (Stage 1), bin scheme.
 

--- a/docs/F-EXECUTOR-GUARDS.md
+++ b/docs/F-EXECUTOR-GUARDS.md
@@ -49,6 +49,11 @@ eventually break (observed locally on the venv314 HA).
 
 ### G2 — stale-SOC guard (P2)
 
+> **v0.14.0 note:** G2's supervisability additionally GATES the
+> F-SEAMLESS-RUNS deadline extension for energy-limited loads — a load G2
+> cannot watch (or has latched) never extends and keeps the R7/R8
+> duty-cycle cap (docs/F-SEAMLESS-RUNS.md).
+
 - **R5** New per-load runtime tracking (in-memory, not persisted): while
   `_load_charging_active[id]` is true AND the power feedback's RAW reading
   passes the existing standby bar (`min_sample_w` — reuse it; do not invent a

--- a/docs/F-PLANNER-HONESTY.md
+++ b/docs/F-PLANNER-HONESTY.md
@@ -30,7 +30,13 @@ planner knows the answer at acceptance time and throws it away.
 - **R1** New core field `SurplusLoadState.learned_power_w: float | None = None`.
   `planning_power_w()` precedence: `measured_power_w` (live, present only
   during/around an active run) > `learned_power_w` > `nominal_power_w`.
-- **R2** The coordinator learns per load the **run-maximum of the accepted-
+- **R2** **Superseded (v0.14.0, docs/F-ROBUST-POWER.md):** the run-max-of-EMA
+  learner below was replaced by a time-weighted windowed MEDIAN estimator
+  after a 60 s compressor-restart transient was EMA-blended and frozen at
+  818 W for a 426 W device (2026-07-18 incident). R1's `planning_power_w`
+  precedence and R3's persistence are unchanged; R2a's seed rule is
+  superseded by the estimator's 5-min warm-up. Original text (historical):
+  the coordinator learns per load the **run-maximum of the accepted-
   sample EMA**: while a run is active and a sample passes the existing
   standby bar (`min_sample_w`, unchanged v0.6.2 semantics), after updating
   `_load_power_ema` set

--- a/docs/F-RESIDUAL-TOPUP.md
+++ b/docs/F-RESIDUAL-TOPUP.md
@@ -122,11 +122,16 @@ known limitations). No simulator changes.
 - **R9** `_maintain_recommendation_deadline` (recommendation-only loads) drops
   its `energy_limited` early-return for the same reason: the published `active`
   flag flips off at the deadline; the FIX-5 re-anchor cycle applies unchanged.
-- **R10 (accepted consequence, document)** If a plan EXTENDS a running
+- **R10 (accepted consequence, document)** ~~If a plan EXTENDS a running
   contiguous block, the frozen cap force-offs at the old `D`; after the
   `min_off` dwell the still-active plan re-ons with a fresh deadline
-  (duty-cycle gap ≤ `min_off`, default 30 min). Harmless for charging
-  powerstations; symmetric with existing non-energy-limited behaviour.
+  (duty-cycle gap ≤ `min_off`, default 30 min).~~ **Superseded (v0.14.0,
+  docs/F-SEAMLESS-RUNS.md):** a G2-supervisable energy-limited load whose
+  fresh plan re-booked a contiguous run at the expired deadline now EXTENDS
+  seamlessly (no OFF/dwell gap). The R7/R8 duty-cycle cap remains exactly
+  for G2-UNSUPERVISABLE loads (no control switch, SOC or power entity, or
+  stale-latched) — including recommendation-only energy-limited loads (R9,
+  FIX-5 cycle unchanged there).
 
 ### Docs / housekeeping
 

--- a/docs/F-ROBUST-POWER.md
+++ b/docs/F-ROBUST-POWER.md
@@ -1,0 +1,109 @@
+# F-ROBUST-POWER — robust per-load planning-power estimation (v0.14.0)
+
+Status: **binding spec**, operator decision 2026-07-18. Implemented in
+`core/power_learning.py` + the sample-buffer rework in `coordinator.py`.
+
+## 1. Incident (root cause, empirically verified)
+
+At the 2026-07-18 06:21 inverter cutoff (the G4 incident,
+docs/LOAD_CONTROL.md §11) the dehumidifier compressor's restart transient —
+**1711 W**, held ~60 s by the measuring plug's update cadence — was blended
+into the then-current EMA: `0.3·1711 + 0.7·433 ≈ 818`. The run-max rule froze
+that blend and persisted it, so a **426 W** device was planned at **818 W**
+for the whole morning; the phantom surplus consumption pushed the fossibot
+into 30-min duty-cycle scraps. The R2a seed rule only protected the FIRST
+sample of a run — mid-run spikes fed the EMA unhindered, and one sample was
+enough to lift it by up to 30 %.
+
+## 2. Operator spec (binding, 2026-07-18)
+
+Planning power = robust average over the recent run window (~30 min sketch).
+SHORT dips and spikes must ALWAYS be ignored (defrost pauses where only a
+small fan runs, compressor inrush, inverter-transfer transients). SUSTAINED
+level changes must be adopted — a durably low draw is real. When the normal
+level (~400 W) returns for a LONGER time (~10 min), it must be re-learned
+quickly. The solution must generalise beyond the dehumidifier: fossibot
+charge rates are operator-changeable and battery-side throttling produces
+legitimate sustained tapers — levels ABOVE the configured nominal power are
+legitimate too (505–701 W at 300 W nominal), so there is **no nominal
+clamp**. Appliances (Waschmaschine) with declared run energy + duration keep
+planning with the DECLARED values (see §6).
+
+## 3. Estimator (core/power_learning.py)
+
+`robust_power_estimate(samples, now) -> PowerEstimate(watts|None,
+coverage_s, fast_adopted)` over ACCEPTED `(timestamp, watts)` samples (the
+caller applies the v0.6.2 standby bar and the runs-at-BM's-request gate —
+both unchanged).
+
+- **Time weighting**: sample i covers `[t_i, min(t_{i+1}, t_i + GAP_CAP_S))`
+  (last sample up to `now`, capped), clipped to the window — sparse and
+  chatty sensors behave identically; a spike followed by silence is credited
+  at most `GAP_CAP_S`.
+- **Slow path**: time-weighted MEDIAN over `WINDOW_S` (1800 s). A level
+  occupying < 50 % of covered time (60 s transfer transient, 8-min defrost
+  dip) cannot move it; a sustained level is adopted once it is the majority
+  (~15 min).
+- **Fast-adopt**: when the last `FAST_WINDOW_S` (600 s) are internally
+  stable (time-weighted P10/P90 within ±`STABLE_BAND` (20 %) of the
+  sub-median) AND the sub-median deviates > `FAST_DEVIATION` (20 %) from the
+  slow median, the sub-median wins immediately — "10 stable minutes
+  re-learn quickly" (operator-changed charge rates included).
+- **Warm-up**: below `WARMUP_COVERAGE_S` (300 s) of accepted coverage the
+  estimate is `None` — start-up inrush can never be served or learned.
+  **Supersedes F-PLANNER-HONESTY R2a** (seed rule) entirely.
+- Module constants only, **no new config keys**: WINDOW 1800 s, FAST 600 s,
+  bands 0.20, WARMUP 300 s, GAP_CAP 300 s, MAX_SAMPLES 720.
+
+## 4. Coordinator wiring
+
+- `_load_power_ema`, `_load_run_power_max`, `_POWER_EMA_ALPHA` are REMOVED.
+  New: `_load_power_samples: dict[str, deque[(ts, watts)]]` with the run's
+  lifecycle (dropped on run end / foreign use; NOT persisted — a stale
+  window must not serve as fresh measurement after a restart).
+- `measured_power_w` = the live estimate while running (None during
+  warm-up → `planning_power_w` falls back to learned/nominal — the seam is
+  unchanged, **no optimizer change, goldens bit-identical**).
+- `learned_power_w` = WRITE-THROUGH of the estimate while running ("last
+  stable estimate wins"; persistence key `load_learned_power` and the
+  vanished-subentry pruning are unchanged). Old persisted values are kept on
+  upgrade — the write-through self-heals within minutes of the first run.
+- Mid-run feedback gap: the buffer estimate keeps serving (v0.5.1
+  semantics); a long outage decays into warm-up rather than a stale value.
+- **3×-nominal WARNING** (change-gated, once per run): the median cannot
+  detect a PLAUSIBLE frozen sensor value (fossibot cached-data flakiness) —
+  gross lies are observed, deliberately not clamped.
+
+## 5. Behavior changes to know
+
+- Runs shorter than ~5 min never learn and serve no measured value
+  (previously the EMA served from sample 1, learned from sample 2).
+- The learned value now FOLLOWS a sustained taper down (operator: "durably
+  low is real") instead of freezing the run maximum. The saturation gate
+  keeps its nominal floor (`max(power, nominal)`, unchanged), so a decayed
+  value still cannot weaken it.
+
+## 6. Appliances: declared values rule (clarification, no code change)
+
+Verified: appliance planning uses ONLY the declared `run_energy_wh` /
+`run_duration_h` (`series._apply_appliance_runs`, `insert_appliance_run`);
+measured power feeds nothing but the on/off detection hysteresis. No learned
+value ever influences appliance planning.
+
+## 7. Tests
+
+`tests/core/test_power_learning.py` (pure): 818 regression (1711 W/60 s →
+estimate stays 420–470 at every step), 8-min dip ignored vs 20-min dip
+adopted, sustained-low via median, fast-adopt stable 10 min (+ oscillating
+counter-case), warm-up None, sparse-vs-chatty equivalence + GAP_CAP,
+window pruning. `tests/ha/test_load_switching.py`: HA-level 818 twin,
+warm-up/gap/run-end lifecycle, F-L6 manual-run gate (semantics verbatim),
+standby bar, persistence round-trip, 3×-nominal warning (served, not
+clamped).
+
+## 8. Residual limitation (accepted)
+
+A frozen-but-plausible sensor value (within 3× nominal) that persists longer
+than the window is indistinguishable from a real level and will be adopted —
+sensor-level lying cannot be fixed at this layer. G2 (stale SOC) covers the
+SOC side; the 3× warning covers gross power lies.

--- a/docs/F-SEAMLESS-RUNS.md
+++ b/docs/F-SEAMLESS-RUNS.md
@@ -1,0 +1,105 @@
+# F-SEAMLESS-RUNS — no artificial OFF at quantum boundaries (v0.14.0)
+
+Status: **binding spec**, operator decision 2026-07-18. Implemented in
+`coordinator.py` (`_seamless_extension_ok`, the deadline branch of
+`_apply_load_switching`, `_maintain_recommendation_deadline`).
+
+## 1. Operator model of min_off (binding)
+
+> "Die Idee von min_off ist nicht, dass das Gerät mindestens die
+> eingestellte Zeit aus ist jede Stunde, sondern dass es mindestens die
+> konfigurierte Zeit aus bleibt, wenn es einmal ABSICHTLICH deaktiviert
+> wurde."
+
+min_off arms ONLY on deliberate deactivations. A booked-quantum boundary
+where the plan wants to continue seamlessly is NOT a deactivation.
+
+## 2. Incident (2026-07-18, observed live)
+
+The plan booked the fossibot in 30-min quanta; the executor force-offed at
+each frozen deadline (`run_start + max(min_runtime, run_h)`), the replan
+re-booked SECONDS later (recommendation off 13:25 → on 13:25), and min_off
+blocked the re-on until :55 — a 50 % duty cycle: pointless relay cycles,
+compressor/charger restart inrushes (which fed the F-ROBUST-POWER 818 W
+incident), and halved charging rates.
+
+## 3. Mechanics
+
+At an EXPIRED run deadline with the load still running, the executor now
+checks THIS refresh's plan (recomputed with fresh remaining/SOC data before
+switching runs):
+
+- Plan re-booked a contiguous run starting now (`active_now` and
+  `plan.active_run_hours(slot_durations) > 0`) AND the load is
+  extension-eligible → **EXTEND**: re-freeze the deadline at `now + booked
+  run` (min 1 min), re-arm the off-timer, no OFF call, **no dwell stamp**.
+- Otherwise → force OFF as before (stamps min_off).
+
+Same semantics for recommendation-only loads in
+`_maintain_recommendation_deadline`: an eligible load re-anchors immediately
+at the expired deadline (no min_runtime floor — it was already served), so
+the published `active` never dips at a boundary. The FIX-5 duty-cycle
+fallback remains for extension-INELIGIBLE loads.
+
+### Eligibility (`_seamless_extension_ok`)
+
+- Continuous loads: always eligible (the deadline is quantum bookkeeping).
+- Energy-limited loads: only while the G2 stale-SOC guard CAN supervise them
+  (control switch + SOC entity + power feedback all configured) AND they are
+  not stale-latched. Anything G2 cannot supervise keeps the F-RESIDUAL-TOPUP
+  R7/R8 duty-cycle cap — including recommendation-only energy-limited loads
+  — because the cap is the only defence against a stale `remaining`
+  stretching a small top-up into an unbounded charge.
+
+### Decision log
+
+- **No min_runtime floor on extensions**: the original deadline was
+  `run_start + max(min_runtime, run)`, so min_runtime is always served
+  before an extension is evaluated; flooring again would over-deliver.
+- **No dwell stamp on extensions**: min_off arms only on real OFFs
+  (plan-off, deadline without re-booking, G1 target stop, G4 floor guard) —
+  exactly the operator's model. The cloud-flap OFF (surplus gone) keeps
+  min_off: that IS deliberate.
+- **Cap per extension = the newly booked contiguous run**, never
+  indefinite: with a stale SOC, G2 latches within `STALE_LOAD_SOC_MIN`
+  (12 min) of frozen-SOC charging evidence, the load goes unavailable, the
+  planner drops it, and the next deadline expires without a re-booking.
+- **No boundary-gap epsilon**: `_spread_energy` fills an earlier slot to its
+  boundary before spilling, so a contiguous continuation is always visible
+  as one unbroken run in the fresh plan; a hole is a deliberate planner
+  pause → OFF + min_off is correct.
+- **Mid-run extensions still do NOT move the deadline** (F-PREDRAIN §5 T9b
+  kept): only AT the expired deadline is the fresh plan consulted.
+
+## 4. Interaction table
+
+| Mechanism | Interaction |
+|---|---|
+| G1 target stop | Unchanged; a real OFF, stamps min_off (anti-flap at target SOC). |
+| G2 stale-SOC | Gates eligibility; a latch forces the deadline OFF path. |
+| G4 floor guard | Checked BEFORE the deadline branch — always wins over an extension. |
+| F-RESIDUAL-TOPUP R7/R8 | Preserved for G2-unsupervisable energy-limited loads (incl. rec-only, R9/FIX-5 duty cycle). |
+| Runtime counter / `_load_is_running` | Read real power/charging state and the moving deadline consistently; no change. |
+| Persistence | `load_run_deadline` already round-trips; an extended deadline survives restarts. |
+
+## 4b. Accepted limitations (review 2026-07-18)
+
+- An IN-FLIGHT switching task at the exact boundary makes the refresh
+  return before the extension is evaluated — the published `active` may dip
+  for one cycle (executor-side harmless; the next refresh extends).
+- Recommendation-only loads UNDER-credit runtime by up to one refresh gap
+  per seamless boundary (counter reads the deadline-capped `active`).
+- The deadline extension is persisted in the extending cycle itself; a
+  restart in the sub-second between set and save falls back to the previous
+  deadline (conservative: earlier force-off path).
+
+## 5. Tests
+
+`tests/ha/test_load_switching.py`: seamless extension (no OFF call, fresh
+deadline ≈ now + booked run, dwell stamp untouched), extension length =
+booked run not min_runtime, deadline-off when NOT re-booked (+ min_off gates
+the re-on), G2-latched energy-limited never extends, energy-limited without
+a power sensor never extends, G4 wins over extension, rec-only seamless
+published `active` never dips, rec-only ENERGY-LIMITED keeps the FIX-5 duty
+cycle, night-block extend/off phases, mid-run extension never moves the
+deadline.

--- a/docs/F-SUBHOUR-ALLOCATION.md
+++ b/docs/F-SUBHOUR-ALLOCATION.md
@@ -91,6 +91,10 @@ simulator (already energy‑ and duration‑exact). No sub‑`min_runtime` runs
 - **R8** Force the load **OFF at `off_at`** via an explicit one‑shot timer
   (`async_track_point_in_time`); the 300 s poll is too coarse to stop mid‑hour.
   The force‑off uses the existing OFF path and stamps `_last_load_switch` (dwell).
+  **Amended (v0.14.0, docs/F-SEAMLESS-RUNS.md):** when THIS refresh's plan
+  re-booked a contiguous run at the expired deadline and the load is
+  extension-eligible, the deadline EXTENDS seamlessly instead (no OFF, no
+  dwell stamp) — the force-off applies only without a re-booking.
 - **R9** The load is also switched off earlier if a later plan makes it inactive
   once past the dwell (surplus vanished), and **never** off before `min_runtime`.
   (Since v0.13.1 ONE exception overrides this: the G4 floor guard forces an

--- a/docs/LOAD_CONTROL.md
+++ b/docs/LOAD_CONTROL.md
@@ -89,9 +89,11 @@ Previously: an energy-limited load with an unreadable SOC ⇒ unavailable.
 
 `total_input` (IN Total) measures input = charging **+** passthrough output.
 From the point of view of the house's AC balance this is correctly the power
-that the load draws while the input is active — it is still used (smoothed)
-as the planning power. The energy progress of the charge is tracked over the
-SOC (ground truth) anyway, not integrated over the power.
+that the load draws while the input is active — since v0.14.0 it feeds the
+ROBUST windowed estimator (docs/F-ROBUST-POWER.md: time-weighted median,
+5-min warm-up, spike/dip immunity) instead of the former EMA. The energy
+progress of the charge is tracked over the SOC (ground truth) anyway, not
+integrated over the power.
 
 ## 6. Further points from the operator's wish list
 
@@ -152,7 +154,7 @@ SOC (ground truth) anyway, not integrated over the power.
   rule is that energy-limited loads never book zero-PV (night) slots. See
   docs/F-GATE-PARITY.md.
 - Alongside this, the coordinator persists the switch dwell across restarts
-  (the loss was a contributing cause). The power EMA is deliberately NOT
+  (the loss was a contributing cause). The live power-sample window is deliberately NOT
   persisted, and on feedback gaps is only served while the load is really
   charging — after charge end, the taper residual (10–40 W) would otherwise
   permanently weaken all gates as "measured" planning power. The log lines
@@ -161,8 +163,9 @@ SOC (ground truth) anyway, not integrated over the power.
   The dehumidifier periodically defrosts briefly (power drops for minutes) and
   stops entirely when the water tank is full (power near 0 W despite an active
   recommendation). Defrost cycles may enter the power average (samples between
-  the standby threshold and the rated power average the EMA; below that the
-  sample is discarded and the EMA is frozen — "totally ruining it" is
+  the standby threshold and the rated power feed the windowed estimator
+  (v0.14.0; the median ignores them as a minority anyway); below the bar the
+  sample is discarded entirely — "totally ruining it" is
   precluded by the 25 % threshold). But if the real power deviates for **longer
   than the per-load dwell** (field "power warning dwell", default 15 min) by
   more than the configured percentage (field "power-deviation warning", default
@@ -193,7 +196,7 @@ SOC (ground truth) anyway, not integrated over the power.
   recommendation is switched on, the metered socket must not yet be drawing,
   otherwise an already-running hand/foreign load would be learned and could
   tip over the next plan via the learned value (flutter loop, review finding).
-  Outside these windows measurements are ignored and any existing EMA is
+  Outside these windows measurements are ignored and the live sample window is
   discarded (planning falls back to the rated power). Together with the standby
   filter (v0.6.2: samples only ≥ max(10 W, 25 % × rated power)) the learned
   power is thus shielded against hand and foreign use.
@@ -201,7 +204,7 @@ SOC (ground truth) anyway, not integrated over the power.
   deliberately counts — the feedback ("IN Total") measures the device itself,
   so a manually started charge yields correct device data; the window is
   bounded by the minimum runtime. Entity outages (unavailable/unknown) never
-  count as "off" here (otherwise the EMA would be discarded mid-charge).
+  count as "off" here (otherwise the sample window would be discarded mid-charge).
 
 ## 9. Target-SOC stop is dwell-exempt behind a charge-enable gate (v0.9.0)
 
@@ -274,3 +277,27 @@ time is the SOC entity's debounced refresh (~5 s), not the dwell. In-memory
 only; surfaced as `floor_guard_active` on the inverter-recommendation
 binary sensor. The planner is deliberately unchanged — G4 is the hard
 executor backstop against forecast error, not a planning rule.
+
+## 12. Robust power learning (v0.14.0)
+
+docs/F-ROBUST-POWER.md, operator spec 2026-07-18 after the 818 W incident
+(a 60 s compressor-restart transient EMA-blended and frozen for a 426 W
+dehumidifier): the planning power of a surplus load is now a TIME-WEIGHTED
+MEDIAN over the run's last ~30 min — short spikes and dips (inrush,
+defrost, transfer transients) can never move it; sustained level changes
+are adopted (~15 min, or ~10 min via the stable fast-adopt window, e.g. an
+operator-changed fossibot charge rate); the first 5 min of a run never
+learn at all. No nominal clamp (levels above nominal are legitimate); a
+3×-nominal estimate logs a change-gated WARNING instead. **Appliances are
+untouched by all of this: their planning always uses the DECLARED run
+energy/duration — measured power only feeds their on/off detection.**
+
+## 13. Seamless quantum boundaries (v0.14.0)
+
+docs/F-SEAMLESS-RUNS.md, operator min_off model 2026-07-18: min_off arms
+ONLY on deliberate deactivations. When a booked quantum ends and THIS
+refresh's plan re-booked a contiguous run, the executor extends the frozen
+deadline seamlessly — no OFF/ON relay cycle, no compressor restart, no
+min_off pause (the observed 50 % duty cycle is gone). Energy-limited loads
+extend only while the G2 stale-SOC guard can supervise them; everything
+G2-unsupervisable keeps the R7/R8 duty-cycle cap. G4 always wins.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "battery-manager-ha"
-version = "0.13.1"
+version = "0.14.0"
 description = "Solar-battery optimizer for Home Assistant: SOC forecast, discharge-threshold planning, surplus-load and grid-support control."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/core/test_power_learning.py
+++ b/tests/core/test_power_learning.py
@@ -1,0 +1,141 @@
+"""Tests for the robust planning-power estimator (docs/F-ROBUST-POWER.md)."""
+
+from datetime import datetime, timedelta
+
+from core.power_learning import (
+    FAST_WINDOW_S,
+    GAP_CAP_S,
+    WARMUP_COVERAGE_S,
+    WINDOW_S,
+    robust_power_estimate,
+)
+
+T0 = datetime(2026, 7, 18, 6, 0)
+
+
+def _stream(*segments, cadence_s=30.0, start=T0):
+    """Build (ts, watts) samples from (duration_s, watts) segments."""
+    samples = []
+    t = start
+    for duration_s, watts in segments:
+        end = t + timedelta(seconds=duration_s)
+        while t < end:
+            samples.append((t, watts))
+            t += timedelta(seconds=cadence_s)
+    return samples, t
+
+
+def test_818_regression_transient_never_learned():
+    """THE incident: a stable 426 W run with ONE 1711 W transient held 60 s
+    (inverter-transfer compressor restart) must never move the estimate —
+    no 818-class value at any evaluation step after warm-up."""
+    samples, now = _stream((1200.0, 426.0), (60.0, 1711.0), (300.0, 426.0))
+    probe = T0 + timedelta(seconds=WARMUP_COVERAGE_S + 30)
+    while probe <= now:
+        est = robust_power_estimate([s for s in samples if s[0] <= probe], probe)
+        if est.watts is not None:
+            assert 420.0 <= est.watts <= 470.0, (
+                f"estimate {est.watts} left the 426 W band at {probe}"
+            )
+        probe += timedelta(seconds=60)
+
+
+def test_short_dip_ignored_sustained_dip_adopted():
+    """A defrost-style 150 W dip of 8 min is ignored; the same dip lasting
+    20 min is the window majority and IS adopted (durably low = real)."""
+    short, now_s = _stream((1500.0, 426.0), (480.0, 150.0))
+    est_short = robust_power_estimate(short, now_s)
+    assert est_short.watts is not None and est_short.watts >= 400.0
+
+    long, now_l = _stream((1500.0, 426.0), (1200.0, 150.0))
+    est_long = robust_power_estimate(long, now_l)
+    assert est_long.watts is not None and est_long.watts <= 160.0
+
+
+def test_sustained_low_adopts_via_median_majority():
+    """The slow median flips once the new level covers >50 % of the window
+    (~15 min) even without the fast-adopt path (oscillation-free ramp)."""
+    samples, now = _stream((900.0, 426.0), (16 * 60.0, 210.0))
+    est = robust_power_estimate(samples, now)
+    assert est.watts is not None and est.watts <= 215.0
+
+
+def test_fast_adopt_stable_10min():
+    """Operator rule: ~10 stable minutes of a new level re-learn quickly —
+    500 W for 20 min, then 300 W stable for 10 min -> ~300 (fast_adopted).
+    An oscillating tail (250/600 alternating) must NOT fast-adopt."""
+    samples, now = _stream((1200.0, 500.0), (FAST_WINDOW_S + 30.0, 300.0))
+    est = robust_power_estimate(samples, now)
+    assert est.watts is not None and abs(est.watts - 300.0) < 1e-6
+    assert est.fast_adopted
+
+    osc = [(60.0, 250.0), (60.0, 600.0)] * 5
+    samples2, now2 = _stream((1200.0, 500.0), *osc)
+    est2 = robust_power_estimate(samples2, now2)
+    assert not est2.fast_adopted
+    assert est2.watts is not None and est2.watts >= 400.0
+
+
+def test_warmup_returns_none():
+    """Below WARMUP_COVERAGE_S of accepted coverage there is NO estimate —
+    a pure-inrush run start can never be served or learned."""
+    samples, now = _stream((WARMUP_COVERAGE_S - 60.0, 1711.0))
+    est = robust_power_estimate(samples, now)
+    assert est.watts is None
+    assert est.coverage_s < WARMUP_COVERAGE_S
+
+
+def test_single_sample_never_clears_warmup():
+    """Review finding (2026-07-18): GAP_CAP_S == WARMUP_COVERAGE_S, so ONE
+    sample followed by silence reaches exactly the coverage bar — it must
+    STILL not produce an estimate (a lone transient caught by the first
+    poll would otherwise be served and learned verbatim)."""
+    one = [(T0, 1711.0)]
+    est = robust_power_estimate(one, T0 + timedelta(seconds=GAP_CAP_S))
+    assert est.watts is None
+    # Two samples where the newest has zero weight (evaluated at its own
+    # timestamp): still only one weight-bearing sample -> no estimate.
+    two = [(T0, 1711.0), (T0 + timedelta(seconds=GAP_CAP_S), 426.0)]
+    est2 = robust_power_estimate(two, T0 + timedelta(seconds=GAP_CAP_S))
+    assert est2.watts is None
+
+
+def test_fast_adopt_needs_two_weightbearing_samples():
+    """A single accepted glitch held by GAP_CAP through a sensor outage
+    must not fast-adopt once it dominates the fast window — the stability
+    test is vacuous on one sample."""
+    samples, last = _stream((1500.0, 426.0))
+    samples.append((last, 150.0))  # one glitch, then the sensor goes silent
+    # ~10 min later the fast window holds (almost) only the glitch.
+    est = robust_power_estimate(samples, last + timedelta(seconds=595.0))
+    assert not est.fast_adopted
+    assert est.watts is not None and est.watts >= 400.0
+
+
+def test_time_weighting_sparse_vs_chatty_equivalent():
+    """A sparse (240 s cadence) and a chatty (5 s cadence) sensor with the
+    same physical shape give equivalent estimates, and a long silence after
+    a spike credits it with at most GAP_CAP_S of weight."""
+    chatty, now_c = _stream((1200.0, 426.0), cadence_s=5.0)
+    sparse, now_s = _stream((1200.0, 426.0), cadence_s=240.0)
+    est_c = robust_power_estimate(chatty, now_c)
+    est_s = robust_power_estimate(sparse, now_s)
+    assert est_c.watts is not None and est_s.watts is not None
+    assert abs(est_c.watts - est_s.watts) < 1.0
+
+    # Spike then 20 min of silence: the spike's weight is capped at
+    # GAP_CAP_S, so the pre-spike level keeps the majority.
+    samples, last = _stream((900.0, 426.0))
+    samples.append((last, 1711.0))
+    now = last + timedelta(seconds=1200.0)
+    est = robust_power_estimate(samples, now)
+    assert est.watts is not None and est.watts <= 470.0
+    # sanity: the spike really was capped, not zero-weighted
+    assert est.coverage_s <= 900.0 + GAP_CAP_S + 1.0
+
+
+def test_window_prune_old_level_has_no_influence():
+    """A level older than WINDOW_S is fully aged out of the estimate."""
+    samples, now_mid = _stream((1200.0, 800.0), (WINDOW_S + 300.0, 426.0))
+    est = robust_power_estimate(samples, now_mid)
+    assert est.watts is not None and abs(est.watts - 426.0) < 1e-6

--- a/tests/ha/test_load_switching.py
+++ b/tests/ha/test_load_switching.py
@@ -282,16 +282,18 @@ async def test_soc_cache_survives_sleeping_device(hass):
 async def test_switch_dwell_survives_restart(hass):
     """The per-load switch dwell must not reset on restart: a wiped
     timestamp allowed switching right after boot (co-factor of the
-    2026-07-05 degenerate-slot-0 night charge). The power EMA is
-    deliberately NOT persisted (a taper-decayed value must not become
-    permanent planning power)."""
+    2026-07-05 degenerate-slot-0 night charge). The live power-sample
+    buffer is deliberately NOT persisted (a stale window must not serve
+    as fresh measurement after a restart)."""
+    from collections import deque
+
     calls: list[tuple[str, str]] = []
     coordinator, sub_id, _data = await _setup(hass, calls)
 
     from homeassistant.util import dt as dt_util
 
     ts = dt_util.utcnow().replace(microsecond=0)
-    coordinator._load_power_ema[sub_id] = 505.4
+    coordinator._load_power_samples[sub_id] = deque([(ts, 505.4)])
     coordinator._last_load_switch[sub_id] = ts
 
     captured: dict = {}
@@ -308,36 +310,54 @@ async def test_switch_dwell_survives_restart(hass):
     from homeassistant.helpers.storage import Store
 
     await coordinator._store.async_save(captured)
-    coordinator._load_power_ema.clear()
+    coordinator._load_power_samples.clear()
     coordinator._last_load_switch.clear()
     coordinator._store = Store(hass, coordinator._store.version, coordinator._store.key)
     await coordinator.async_load_persistent_state()
     assert coordinator._last_load_switch == {sub_id: ts}
-    assert coordinator._load_power_ema == {}
+    assert coordinator._load_power_samples == {}
 
 
-async def test_power_ema_serves_only_while_charging(hass):
-    """A feedback gap keeps the EMA only DURING an active charge (v0.5.1
-    rule); after the charge the taper-decayed value is discarded so the
-    planner falls back to the nominal power."""
+def _warm_power(hass, coordinator, watts, *, start=None, minutes=6.0, step_s=30.0):
+    """Feed an accepted-sample stream (F-ROBUST-POWER warm-up helper).
+
+    Sets the feedback sensor to `watts` and drives `_get_load_states` with
+    synthetic advancing timestamps until `minutes` of coverage exist —
+    past the 5-min warm-up the robust estimate serves. Returns (states,
+    now) of the last cycle."""
+    from homeassistant.util import dt as dt_util
+
+    now = start or dt_util.utcnow()
+    hass.states.async_set(POWER_FEEDBACK, str(watts))
+    states = None
+    end = now + timedelta(minutes=minutes)
+    while now <= end:
+        states = coordinator._get_load_states(now)
+        now += timedelta(seconds=step_s)
+    return states, now
+
+
+async def test_power_estimate_serves_only_while_charging(hass):
+    """A feedback gap keeps the estimate only DURING an active charge
+    (v0.5.1 rule); after the charge the buffer is discarded so the planner
+    falls back to the learned/nominal power."""
     calls: list[tuple[str, str]] = []
     coordinator, sub_id, _data = await _setup(hass, calls)
     coordinator._load_charging_active[sub_id] = True  # BM-initiated charge
-    hass.states.async_set(POWER_FEEDBACK, "505")
 
-    states = coordinator._get_load_states()
+    states, now = _warm_power(hass, coordinator, 505)
     assert states[0].measured_power_w == 505.0
 
-    # Feedback drops out mid-charge: last smoothed value keeps serving.
+    # Feedback drops out mid-charge: the buffer estimate keeps serving.
     hass.states.async_set(POWER_FEEDBACK, "0")
-    states = coordinator._get_load_states()
+    states = coordinator._get_load_states(now + timedelta(seconds=60))
     assert states[0].measured_power_w == 505.0
 
-    # Charge over: the EMA is dropped, planning returns to nominal power.
+    # Charge over: the buffer is dropped, planning returns to learned.
     coordinator._load_charging_active[sub_id] = False
-    states = coordinator._get_load_states()
+    states = coordinator._get_load_states(now + timedelta(seconds=120))
     assert states[0].measured_power_w is None
-    assert sub_id not in coordinator._load_power_ema
+    assert sub_id not in coordinator._load_power_samples
 
 
 async def test_standby_power_never_seeds_ema(hass):
@@ -353,35 +373,34 @@ async def test_standby_power_never_seeds_ema(hass):
 
     states = coordinator._get_load_states()
     assert states[0].measured_power_w is None  # planner uses nominal 400 W
-    assert sub_id not in coordinator._load_power_ema
+    assert sub_id not in coordinator._load_power_samples
 
 
 async def test_operating_power_above_standby_threshold_is_learned(hass):
     """A real operating value (350 W of 400 W nominal) is above the
-    standby threshold and seeds the EMA; when the device drops back to
-    standby without an active charge, the EMA is discarded again."""
+    standby threshold and feeds the estimator; when the device drops back
+    to standby without an active charge, the buffer is discarded again."""
     calls: list[tuple[str, str]] = []
     coordinator, sub_id, _data = await _setup(hass, calls, power_w=400.0)
     coordinator._load_charging_active[sub_id] = True  # BM-initiated charge
-    hass.states.async_set(POWER_FEEDBACK, "350")
 
-    states = coordinator._get_load_states()
+    states, now = _warm_power(hass, coordinator, 350)
     assert states[0].measured_power_w == 350.0
 
-    # Back to standby draw, run over: the learned value must not linger.
+    # Back to standby draw, run over: the measured value must not linger.
     coordinator._load_charging_active[sub_id] = False
     hass.states.async_set(POWER_FEEDBACK, "19.6")
-    states = coordinator._get_load_states()
+    states = coordinator._get_load_states(now)
     assert states[0].measured_power_w is None
-    assert sub_id not in coordinator._load_power_ema
+    assert sub_id not in coordinator._load_power_samples
 
 
 async def test_manual_run_never_trains_planning_power(hass):
     """Operator decision F-L6 (2026-07-05): a manual activation (or a
     foreign consumer on the measured outlet) must not influence future
-    planning. For a recommendation-only load, samples train the EMA only
-    during an activation that started with an idle outlet — the draw then
-    provably happened in response to the plan."""
+    planning. For a recommendation-only load, samples feed the estimator
+    only during an activation that started with an idle outlet — the draw
+    then provably happened in response to the plan."""
     from types import SimpleNamespace
 
     calls: list[tuple[str, str]] = []
@@ -398,7 +417,7 @@ async def test_manual_run_never_trains_planning_power(hass):
     coordinator._update_plan_active(off)
     states = coordinator._get_load_states()
     assert states[0].measured_power_w is None
-    assert sub_id not in coordinator._load_power_ema
+    assert sub_id not in coordinator._load_power_samples
 
     # Plan activates WHILE the manual draw is ongoing (dirty edge): the
     # pre-existing draw still must not train — repeatedly (stability!).
@@ -406,23 +425,22 @@ async def test_manual_run_never_trains_planning_power(hass):
     for _ in range(3):
         states = coordinator._get_load_states()
         assert states[0].measured_power_w is None
-        assert sub_id not in coordinator._load_power_ema
+        assert sub_id not in coordinator._load_power_samples
 
     # Clean cycle: recommendation off, outlet idle, then a fresh edge —
-    # now the draw follows the plan and is a legitimate sample.
+    # now the draw follows the plan and is a legitimate warmed stream.
     coordinator._update_plan_active(off)
     hass.states.async_set(POWER_FEEDBACK, "5")
     coordinator._update_plan_active(on)
-    hass.states.async_set(POWER_FEEDBACK, "400")
-    states = coordinator._get_load_states()
+    states, now = _warm_power(hass, coordinator, 400)
     assert states[0].measured_power_w == 400.0
 
-    # Recommendation ends, device back to standby: EMA is discarded.
+    # Recommendation ends, device back to standby: the buffer is discarded.
     coordinator._update_plan_active(off)
     hass.states.async_set(POWER_FEEDBACK, "19.6")
-    states = coordinator._get_load_states()
+    states = coordinator._get_load_states(now)
     assert states[0].measured_power_w is None
-    assert sub_id not in coordinator._load_power_ema
+    assert sub_id not in coordinator._load_power_samples
 
 
 async def test_charging_state_survives_entity_dropout(hass):
@@ -882,11 +900,14 @@ async def test_energy_limited_on_arms_deadline_and_forces_off_when_stale(hass):
     assert 29.0 <= (off_at - t0).total_seconds() / 60.0 <= 31.0
     assert sub_id in coordinator._load_off_timer  # one-shot timer armed
 
-    # Stale SOC: the plan still shows the load active past the deadline. The cap
-    # must force it OFF regardless (the level-driven stop never fired).
+    # Stale SOC: the plan still shows the load active past the deadline.
+    # F-SEAMLESS-RUNS: a G2-LATCHED energy-limited load is extension-
+    # ineligible, so the R7/R8 cap must force it OFF regardless (the
+    # level-driven stop never fired).
     hass.states.async_set(PLUG, "on")
     hass.states.async_set(ENABLE, "on")
     coordinator._load_charging_active[sub_id] = True
+    coordinator._load_soc_stale[sub_id] = 40.0  # G2 latched -> no extension
     calls.clear()
     result = SimpleNamespace(
         load_plans=[
@@ -961,9 +982,10 @@ async def test_off_clears_deadline_and_timer(hass):
     assert sub_id not in coordinator._load_off_timer
 
 
-async def test_deadline_forces_off_even_when_plan_wants_on(hass):
-    """Once the frozen deadline passes, the load is switched OFF even though the
-    plan still wants it on (F-SUBHOUR R8)."""
+async def test_deadline_forces_off_when_plan_not_rebooked(hass):
+    """Once the frozen deadline passes and THIS refresh's plan did NOT
+    re-book the load, it is switched OFF (F-SUBHOUR R8; the re-booked case
+    extends seamlessly instead — F-SEAMLESS-RUNS)."""
     from types import SimpleNamespace
 
     from homeassistant.util import dt as dt_util
@@ -972,6 +994,11 @@ async def test_deadline_forces_off_even_when_plan_wants_on(hass):
 
     calls: list[tuple[str, str]] = []
     coordinator, sub_id, data = await _setup(hass, calls, energy_limited=False)
+    # Hermetic executor test: detach the entity listener so no debounced
+    # background refresh (real plan) interferes with the primed state.
+    coordinator._unsub_state_listener()
+    coordinator._unsub_state_listener = None
+    coordinator._listeners_setup = False
     hass.states.async_set(PLUG, "on")
     hass.states.async_set(ENABLE, "on")
     coordinator._load_charging_active[sub_id] = True
@@ -981,9 +1008,9 @@ async def test_deadline_forces_off_even_when_plan_wants_on(hass):
         load_plans=[
             LoadPlan(
                 load_id=sub_id,
-                schedule=(True,),
+                schedule=(False,),
                 planned_energy_wh=0.0,
-                run_hours=(0.5,),
+                run_hours=(0.0,),
             )
         ]
     )
@@ -991,6 +1018,263 @@ async def test_deadline_forces_off_even_when_plan_wants_on(hass):
     await hass.async_block_till_done()
     assert ("turn_off", ENABLE) in calls or ("turn_off", PLUG) in calls
     assert sub_id not in coordinator._load_run_deadline
+
+
+async def test_deadline_extends_seamlessly_when_plan_rebooks(hass):
+    """F-SEAMLESS-RUNS: at an expired deadline with a freshly re-booked
+    contiguous run, the load keeps running — no OFF call, the deadline
+    re-freezes at now + booked run, and NO dwell is stamped (min_off arms
+    only on deliberate deactivations)."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.battery_manager.core.model import LoadPlan
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, data = await _setup(hass, calls, energy_limited=False)
+    # Hermetic executor test: detach the entity listener so no debounced
+    # background refresh (real plan) interferes with the primed state.
+    coordinator._unsub_state_listener()
+    coordinator._unsub_state_listener = None
+    coordinator._listeners_setup = False
+    hass.states.async_set(PLUG, "on")
+    hass.states.async_set(ENABLE, "on")
+    await hass.async_block_till_done()  # drain the debounced background refresh
+    coordinator._load_charging_active[sub_id] = True
+    now = dt_util.utcnow()
+    coordinator._load_run_deadline[sub_id] = now - timedelta(minutes=1)
+    calls.clear()
+    rebooked = SimpleNamespace(
+        load_plans=[
+            LoadPlan(
+                load_id=sub_id,
+                schedule=(True,),
+                planned_energy_wh=0.0,
+                run_hours=(0.5,),
+            )
+        ]
+    )
+    await coordinator._apply_load_switching(rebooked, now, (0.5,))
+    await hass.async_block_till_done()
+    assert calls == []  # no OFF/ON cycle at the boundary
+    assert coordinator._load_charging_active[sub_id] is True
+    new_deadline = coordinator._load_run_deadline[sub_id]
+    assert 29.0 <= (new_deadline - now).total_seconds() / 60.0 <= 31.0
+    assert sub_id not in coordinator._last_load_switch  # no dwell stamp
+    coordinator._cancel_off_timer(sub_id)
+
+
+async def test_extension_uses_booked_run_not_min_runtime(hass):
+    """F-SEAMLESS-RUNS: the extension covers exactly the newly booked run —
+    min_runtime is NOT re-applied as a floor (it was already served by the
+    original run)."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.battery_manager.core.model import LoadPlan
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, data = await _setup(
+        hass, calls, energy_limited=False, min_runtime_min=30
+    )
+    # Hermetic executor test: detach the entity listener so no debounced
+    # background refresh (real plan) interferes with the primed state.
+    coordinator._unsub_state_listener()
+    coordinator._unsub_state_listener = None
+    coordinator._listeners_setup = False
+    hass.states.async_set(PLUG, "on")
+    hass.states.async_set(ENABLE, "on")
+    await hass.async_block_till_done()  # drain the debounced background refresh
+    coordinator._load_charging_active[sub_id] = True
+    now = dt_util.utcnow()
+    coordinator._load_run_deadline[sub_id] = now - timedelta(seconds=10)
+    rebooked = SimpleNamespace(
+        load_plans=[
+            LoadPlan(
+                load_id=sub_id,
+                schedule=(True,),
+                planned_energy_wh=0.0,
+                run_hours=(0.2,),
+            )
+        ]
+    )
+    await coordinator._apply_load_switching(rebooked, now, (1.0,))
+    await hass.async_block_till_done()
+    new_deadline = coordinator._load_run_deadline[sub_id]
+    assert 11.0 <= (new_deadline - now).total_seconds() / 60.0 <= 13.0  # 0.2 h
+    coordinator._cancel_off_timer(sub_id)
+
+
+async def test_energy_limited_supervisable_extends_seamlessly(hass):
+    """F-SEAMLESS-RUNS headline case: an ENERGY-LIMITED load with control
+    switch + readable SOC + readable power feedback and no G2 latch DOES
+    extend seamlessly at the boundary — the fossibot charges through
+    back-to-back quanta without the 30-min pauses."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.battery_manager.core.model import LoadPlan
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, data = await _setup(hass, calls, energy_limited=True)
+    # Hermetic executor test: detach the entity listener so no debounced
+    # background refresh (real plan) interferes with the primed state.
+    coordinator._unsub_state_listener()
+    coordinator._unsub_state_listener = None
+    coordinator._listeners_setup = False
+    hass.states.async_set(PLUG, "on")
+    hass.states.async_set(ENABLE, "on")
+    hass.states.async_set(FOSSI_SOC, "40", {"unit_of_measurement": "%"})
+    hass.states.async_set(POWER_FEEDBACK, "505")
+    await hass.async_block_till_done()  # drain the debounced background refresh
+    coordinator._load_charging_active[sub_id] = True
+    now = dt_util.utcnow()
+    coordinator._load_run_deadline[sub_id] = now - timedelta(minutes=1)
+    calls.clear()
+    rebooked = SimpleNamespace(
+        load_plans=[
+            LoadPlan(
+                load_id=sub_id,
+                schedule=(True,),
+                planned_energy_wh=0.0,
+                run_hours=(0.5,),
+            )
+        ]
+    )
+    await coordinator._apply_load_switching(rebooked, now, (0.5,))
+    await hass.async_block_till_done()
+    assert calls == []  # no OFF/ON cycle
+    assert coordinator._load_charging_active[sub_id] is True
+    assert coordinator._load_run_deadline[sub_id] > now
+    coordinator._cancel_off_timer(sub_id)
+
+
+async def test_energy_limited_unreadable_sensor_never_extends(hass):
+    """F-SEAMLESS-RUNS eligibility (review hardening): entities merely
+    CONFIGURED are not enough — during a sensor outage G2 gathers no
+    evidence, so the extension must be denied and the R7/R8 cap forces
+    the OFF."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.battery_manager.core.model import LoadPlan
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, data = await _setup(hass, calls, energy_limited=True)
+    # Hermetic executor test: detach the entity listener so no debounced
+    # background refresh (real plan) interferes with the primed state.
+    coordinator._unsub_state_listener()
+    coordinator._unsub_state_listener = None
+    coordinator._listeners_setup = False
+    hass.states.async_set(PLUG, "on")
+    hass.states.async_set(ENABLE, "on")
+    hass.states.async_set(FOSSI_SOC, "unavailable")  # sensor outage
+    hass.states.async_set(POWER_FEEDBACK, "505")
+    await hass.async_block_till_done()  # drain the debounced background refresh
+    coordinator._load_charging_active[sub_id] = True
+    now = dt_util.utcnow()
+    coordinator._load_run_deadline[sub_id] = now - timedelta(minutes=1)
+    calls.clear()
+    rebooked = SimpleNamespace(
+        load_plans=[
+            LoadPlan(
+                load_id=sub_id,
+                schedule=(True,),
+                planned_energy_wh=0.0,
+                run_hours=(0.5,),
+            )
+        ]
+    )
+    await coordinator._apply_load_switching(rebooked, now, (0.5,))
+    await hass.async_block_till_done()
+    assert ("turn_off", ENABLE) in calls or ("turn_off", PLUG) in calls
+    assert sub_id not in coordinator._load_run_deadline
+
+
+async def test_energy_limited_without_power_sensor_never_extends(hass):
+    """F-SEAMLESS-RUNS eligibility: an energy-limited load WITHOUT a power
+    feedback sensor is G2-unsupervisable — the R7/R8 cap stays, no
+    extension, forced OFF at the deadline."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.battery_manager.core.model import LoadPlan
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, data = await _setup(
+        hass, calls, energy_limited=True, power_entity=None
+    )
+    # Hermetic executor test: detach the entity listener so no debounced
+    # background refresh (real plan) interferes with the primed state.
+    coordinator._unsub_state_listener()
+    coordinator._unsub_state_listener = None
+    coordinator._listeners_setup = False
+    hass.states.async_set(PLUG, "on")
+    hass.states.async_set(ENABLE, "on")
+    await hass.async_block_till_done()  # drain the debounced background refresh
+    coordinator._load_charging_active[sub_id] = True
+    now = dt_util.utcnow()
+    coordinator._load_run_deadline[sub_id] = now - timedelta(minutes=1)
+    calls.clear()
+    rebooked = SimpleNamespace(
+        load_plans=[
+            LoadPlan(
+                load_id=sub_id,
+                schedule=(True,),
+                planned_energy_wh=0.0,
+                run_hours=(0.5,),
+            )
+        ]
+    )
+    await coordinator._apply_load_switching(rebooked, now, (0.5,))
+    await hass.async_block_till_done()
+    assert ("turn_off", ENABLE) in calls or ("turn_off", PLUG) in calls
+    assert sub_id not in coordinator._load_run_deadline
+
+
+async def test_g4_wins_over_extension(hass):
+    """G4 ordering: an active floor guard forces OFF even when the plan
+    re-booked a contiguous run at the expired deadline."""
+    from types import SimpleNamespace
+
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.battery_manager.core.model import LoadPlan
+
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, data = await _setup(hass, calls, energy_limited=False)
+    # Hermetic executor test: detach the entity listener so no debounced
+    # background refresh (real plan) interferes with the primed state.
+    coordinator._unsub_state_listener()
+    coordinator._unsub_state_listener = None
+    coordinator._listeners_setup = False
+    hass.states.async_set(PLUG, "on")
+    hass.states.async_set(ENABLE, "on")
+    hass.states.async_set("sensor.test_soc", "19", {"unit_of_measurement": "%"})
+    await hass.async_block_till_done()  # drain the debounced background refresh
+    coordinator._load_charging_active[sub_id] = True
+    coordinator._floor_guard_active = True
+    now = dt_util.utcnow()
+    coordinator._load_run_deadline[sub_id] = now - timedelta(minutes=1)
+    calls.clear()
+    rebooked = SimpleNamespace(
+        load_plans=[
+            LoadPlan(
+                load_id=sub_id,
+                schedule=(True,),
+                planned_energy_wh=0.0,
+                run_hours=(0.5,),
+            )
+        ]
+    )
+    await coordinator._apply_load_switching(rebooked, now, (0.5,))
+    await hass.async_block_till_done()
+    assert ("turn_off", ENABLE) in calls or ("turn_off", PLUG) in calls
 
 
 async def test_min_off_dwell_blocks_re_on(hass):
@@ -1062,12 +1346,11 @@ async def test_recommendation_only_load_active_flips_at_deadline(hass):
     coordinator._cancel_off_timer(sub_id)
 
 
-async def test_rec_only_deadline_reanchors_and_is_not_wedged(hass):
-    """FIX-5: a recommendation-only load whose plan stays continuously active for a
-    long block (a night pre-drain glued to the following day) must not stay wedged
-    OFF after the first frozen deadline. The published `active` goes False at the
-    deadline, and once the min_off dwell elapses the deadline RE-ANCHORS so it goes
-    True again — a controlled load's force-off -> dwell -> re-on, published-only."""
+async def test_rec_only_seamless_published_active_never_dips(hass):
+    """F-SEAMLESS-RUNS (supersedes the FIX-5 duty-cycle for eligible loads):
+    a recommendation-only CONTINUOUS load whose plan stays active across a
+    quantum boundary re-anchors IMMEDIATELY at the expired deadline — the
+    published `active` the operator's automation follows never dips."""
     from homeassistant.util import dt as dt_util
 
     from custom_components.battery_manager.core.model import LoadPlan
@@ -1080,7 +1363,6 @@ async def test_rec_only_deadline_reanchors_and_is_not_wedged(hass):
         min_runtime_min=30,
         min_off_min=30,
     )
-    # A 4 h contiguous block from slot 0 (deadline = run_start + 240 min).
     plan = LoadPlan(
         load_id=sub_id,
         schedule=(True,) * 4,
@@ -1094,19 +1376,55 @@ async def test_rec_only_deadline_reanchors_and_is_not_wedged(hass):
     d0 = coordinator._load_run_deadline[sub_id]
     assert coordinator._effective_load_active(plan, now) is True
 
-    # Just past the first deadline: published active is capped OFF.
+    # At the expired boundary the maintain call re-anchors right away —
+    # after the cycle the published active reads True again (no dip).
+    t1 = d0 + timedelta(seconds=30)
+    coordinator._maintain_recommendation_deadline(sub_id, data, plan, t1, durations)
+    assert coordinator._load_run_deadline[sub_id] > d0
+    assert coordinator._effective_load_active(plan, t1) is True
+    coordinator._cancel_off_timer(sub_id)
+
+
+async def test_rec_only_energy_limited_keeps_duty_cycle(hass):
+    """FIX-5 fallback preserved: a recommendation-only ENERGY-LIMITED load is
+    G2-unsupervisable and extension-INELIGIBLE — at the expired deadline the
+    published `active` dips and re-anchors only after the min_off dwell
+    (the F-RESIDUAL-TOPUP R9 duty-cycle cap)."""
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.battery_manager.core.model import LoadPlan
+
+    coordinator, sub_id, data = await _setup(
+        hass,
+        [],
+        energy_limited=True,
+        with_control_switch=False,
+        min_runtime_min=30,
+        min_off_min=30,
+    )
+    plan = LoadPlan(
+        load_id=sub_id,
+        schedule=(True,) * 4,
+        planned_energy_wh=1600.0,
+        run_hours=(1.0,) * 4,
+    )
+    durations = (1.0,) * 4
+    now = dt_util.utcnow()
+
+    coordinator._maintain_recommendation_deadline(sub_id, data, plan, now, durations)
+    d0 = coordinator._load_run_deadline[sub_id]
+    assert coordinator._effective_load_active(plan, now) is True
+
+    # Past the deadline, before min_off: wedged OFF, deadline unchanged.
     t1 = d0 + timedelta(minutes=1)
-    assert coordinator._effective_load_active(plan, t1) is False
-    # Re-evaluated before min_off elapses: still wedged, deadline unchanged.
     coordinator._maintain_recommendation_deadline(sub_id, data, plan, t1, durations)
     assert coordinator._load_run_deadline[sub_id] == d0
     assert coordinator._effective_load_active(plan, t1) is False
 
-    # Once min_off (30 min) has elapsed since the deadline: re-anchor -> active.
+    # After min_off: re-anchored (duty cycle, not a permanent wedge).
     t2 = d0 + timedelta(minutes=31)
     coordinator._maintain_recommendation_deadline(sub_id, data, plan, t2, durations)
-    d1 = coordinator._load_run_deadline[sub_id]
-    assert d1 > d0  # re-anchored (not wedged for the rest of the block)
+    assert coordinator._load_run_deadline[sub_id] > d0
     assert coordinator._effective_load_active(plan, t2) is True
     coordinator._cancel_off_timer(sub_id)
 
@@ -1645,21 +1963,32 @@ async def test_night_block_runs_exactly_planned_hours_then_force_off(hass):
     assert calls == []
     assert coordinator._load_charging_active[sub_id] is True
 
-    # Past the deadline: force off despite the plan still wanting it on.
+    # Past the deadline with the plan STILL booking a contiguous run: the
+    # run extends seamlessly (F-SEAMLESS-RUNS) — no OFF, fresh deadline.
     calls.clear()
-    await coordinator._apply_load_switching(
-        result, off_at + timedelta(minutes=1), durations
-    )
+    t_ext = off_at + timedelta(minutes=1)
+    await coordinator._apply_load_switching(result, t_ext, durations)
+    await hass.async_block_till_done()
+    assert calls == []
+    assert coordinator._load_run_deadline[sub_id] > off_at
+
+    # Past the deadline WITHOUT a re-booked run: forced off (R8 kept).
+    inactive = _inactive_result(sub_id)
+    calls.clear()
+    t_off = coordinator._load_run_deadline[sub_id] + timedelta(minutes=1)
+    await coordinator._apply_load_switching(inactive, t_off, durations)
     await hass.async_block_till_done()
     assert ("turn_off", PLUG) in calls or ("turn_off", ENABLE) in calls
     assert sub_id not in coordinator._load_run_deadline
     coordinator._cancel_off_timer(sub_id)
 
 
-async def test_extended_plan_still_force_offs_and_min_off_gates_re_on(hass):
-    """(b) If the plan EXTENDS mid-run, the frozen deadline must not move (no
-    endless run); at the ORIGINAL deadline the load force-offs, and the min_off
-    dwell then blocks the immediate re-on (F-PREDRAIN §5 T9b)."""
+async def test_extended_plan_extends_at_deadline_and_min_off_after_real_off(hass):
+    """(b, F-SEAMLESS-RUNS revision of F-PREDRAIN §5 T9b) A mid-run plan
+    extension must not move the frozen deadline (no endless run) — but AT
+    the deadline a still-booked plan now extends seamlessly instead of
+    force-offing. A real deactivation then switches off and arms min_off,
+    which blocks the immediate re-on."""
     from types import SimpleNamespace
 
     from homeassistant.util import dt as dt_util
@@ -1681,7 +2010,7 @@ async def test_extended_plan_still_force_offs_and_min_off_gates_re_on(hass):
     off_at = coordinator._load_run_deadline[sub_id]
     assert 119.0 <= (off_at - now).total_seconds() / 60.0 <= 121.0
 
-    # Plan extends to 4 h mid-run: the frozen deadline must NOT move.
+    # Plan extends to 4 h MID-RUN: the frozen deadline must NOT move.
     extended = SimpleNamespace(load_plans=[_night_plan(sub_id, 4)])
     calls.clear()
     await coordinator._apply_load_switching(
@@ -1691,18 +2020,32 @@ async def test_extended_plan_still_force_offs_and_min_off_gates_re_on(hass):
     assert coordinator._load_run_deadline[sub_id] == off_at  # unchanged
     assert calls == []  # still running, no switch
 
-    # Past the ORIGINAL deadline: force off despite the extended plan.
+    # AT the (expired) deadline the extended plan is a re-booking: the run
+    # continues seamlessly with a fresh deadline, no OFF, and no NEW dwell
+    # stamp (the ON-edge stamp from the run start stays untouched).
+    stamp_before = coordinator._last_load_switch.get(sub_id)
     off_now = off_at + timedelta(minutes=1)
     calls.clear()
     await coordinator._apply_load_switching(extended, off_now, durations)
     await hass.async_block_till_done()
-    assert ("turn_off", PLUG) in calls or ("turn_off", ENABLE) in calls
-    assert sub_id not in coordinator._load_run_deadline
+    assert calls == []
+    assert coordinator._load_run_deadline[sub_id] > off_at
+    assert coordinator._last_load_switch.get(sub_id) == stamp_before
 
-    # min_off (45) blocks the immediate re-on even though the plan wants it on.
+    # A REAL deactivation (plan off) switches off and stamps the dwell.
+    inactive = _inactive_result(sub_id)
     calls.clear()
     await coordinator._apply_load_switching(
-        extended, off_now + timedelta(minutes=10), durations
+        inactive, off_now + timedelta(minutes=5), durations
+    )
+    await hass.async_block_till_done()
+    assert ("turn_off", PLUG) in calls or ("turn_off", ENABLE) in calls
+
+    # min_off (45) blocks the immediate re-on even though the plan wants on.
+    t_off = off_now + timedelta(minutes=5)
+    calls.clear()
+    await coordinator._apply_load_switching(
+        extended, t_off + timedelta(minutes=10), durations
     )
     await hass.async_block_till_done()
     assert calls == []
@@ -1710,7 +2053,7 @@ async def test_extended_plan_still_force_offs_and_min_off_gates_re_on(hass):
     # After the min_off dwell elapses the re-on is allowed.
     calls.clear()
     await coordinator._apply_load_switching(
-        extended, off_now + timedelta(minutes=46), durations
+        extended, t_off + timedelta(minutes=46), durations
     )
     await hass.async_block_till_done()
     assert ("turn_on", PLUG) in calls or ("turn_on", ENABLE) in calls
@@ -1830,6 +2173,11 @@ async def test_floor_guard_blocks_switch_on(hass):
     coordinator, sub_id, _data = await _setup(hass, calls, energy_limited=False)
     hass.states.async_set(PLUG, "off")
     hass.states.async_set(ENABLE, "off")
+    # Pin the house SOC below the floor so any BACKGROUND refresh triggered
+    # by the entity events above keeps the guard tripped too (hermetic).
+    hass.states.async_set("sensor.test_soc", "19", {"unit_of_measurement": "%"})
+    await hass.async_block_till_done()  # drain setup-cycle actuations
+    calls.clear()  # assert only THIS test's switching below
     config = coordinator.build_system_config()
     assert coordinator._update_floor_guard(19.0, config) is True
 
@@ -1894,6 +2242,11 @@ async def test_floor_guard_drops_queued_switch_on(hass):
     coordinator, sub_id, data = await _setup(hass, calls, energy_limited=False)
     hass.states.async_set(PLUG, "off")
     hass.states.async_set(ENABLE, "off")
+    # Pin the house SOC below the floor: the drop-path's catch-up refresh
+    # runs a REAL cycle, which must keep the guard tripped (hermetic).
+    hass.states.async_set("sensor.test_soc", "19", {"unit_of_measurement": "%"})
+    await hass.async_block_till_done()  # drain setup-cycle actuations
+    calls.clear()  # assert only the drop path below
     coordinator._floor_guard_active = True  # tripped after the action was queued
     await coordinator._execute_load_switching(
         [(sub_id, data, True, False, 1.0)], dt_util.utcnow()
@@ -1967,43 +2320,40 @@ async def test_floor_guard_caps_published_active(hass):
 
 
 # ---------------------------------------------------------------------------
-# F-PLANNER-HONESTY F1: learned planning power (docs/F-PLANNER-HONESTY.md
-# R2/R3/R6). The run-max of the accepted-sample EMA survives the run (and
-# restarts), so an OFF load is planned at its real power instead of the
-# nominal; the v0.6.2 standby bar stays the single sample gate.
+# Learned planning power (docs/F-ROBUST-POWER.md, supersedes the
+# F-PLANNER-HONESTY R2 run-max-of-EMA): the write-through of the robust
+# windowed estimate survives the run (and restarts), so an OFF load is
+# planned at its real power instead of the nominal; the v0.6.2 standby bar
+# stays the single sample gate.
 # ---------------------------------------------------------------------------
 
 
-async def test_learned_power_is_run_max_of_ema(hass):
-    """R2: the learned value is the RUN-MAX of the accepted-sample EMA — an
-    end-of-charge taper cannot erode it — and it keeps serving after the run
-    ends (unlike the live EMA, which is deliberately discarded)."""
+async def test_learned_power_is_robust_estimate(hass):
+    """F-ROBUST-POWER (supersedes R2 run-max): the learned value is the
+    write-through of the robust windowed estimate — a SHORT end-of-charge
+    taper is a window minority and cannot erode it — and it keeps serving
+    after the run ends (the live buffer is discarded)."""
     calls: list[tuple[str, str]] = []
     coordinator, sub_id, _data = await _setup(hass, calls)
     coordinator._load_charging_active[sub_id] = True  # BM-initiated charge
-    hass.states.async_set(POWER_FEEDBACK, "505")
 
-    states = coordinator._get_load_states()
+    states, now = _warm_power(hass, coordinator, 505)
     assert states[0].measured_power_w == 505.0
-    # R2a: the first accepted sample seeds the EMA only — nothing learned yet.
-    assert sub_id not in coordinator._load_learned_power_w
-    states = coordinator._get_load_states()  # second accepted sample
     assert coordinator._load_learned_power_w[sub_id] == 505.0
     assert states[0].learned_power_w == 505.0
 
-    # End-of-charge taper (still above the standby bar): the EMA sinks, the
-    # learned run-max does not.
-    hass.states.async_set(POWER_FEEDBACK, "320")
-    states = coordinator._get_load_states()
-    assert states[0].measured_power_w < 505.0
+    # Short end-of-charge taper (3 min, still above the standby bar): a
+    # window minority — measured and learned both hold the run level.
+    states, now = _warm_power(hass, coordinator, 320, start=now, minutes=3.0)
+    assert states[0].measured_power_w == 505.0
     assert coordinator._load_learned_power_w[sub_id] == 505.0
 
-    # Run over: the live EMA is dropped (v0.5.1), the learned value serves —
-    # an OFF load now plans at its real 505 W, not the nominal 300 W.
+    # Run over: the buffer is dropped, the learned value serves — an OFF
+    # load now plans at its real 505 W, not the nominal 300 W.
     coordinator._load_charging_active[sub_id] = False
-    states = coordinator._get_load_states()
+    states = coordinator._get_load_states(now)
     assert states[0].measured_power_w is None
-    assert sub_id not in coordinator._load_run_power_max  # run tracker ends
+    assert sub_id not in coordinator._load_power_samples
     assert states[0].learned_power_w == 505.0
     from custom_components.battery_manager.core.model import SurplusLoad
 
@@ -2014,60 +2364,47 @@ async def test_learned_power_is_run_max_of_ema(hass):
 
 
 async def test_learned_power_last_run_wins(hass):
-    """R2: the store holds the CURRENT run's max once it has enough accepted
-    samples — a later, genuinely lower-powered run replaces the old value."""
+    """The store holds the CURRENT run's robust estimate — a later,
+    genuinely lower-powered run replaces the old value once warmed."""
     calls: list[tuple[str, str]] = []
     coordinator, sub_id, _data = await _setup(hass, calls)
     coordinator._load_charging_active[sub_id] = True
-    hass.states.async_set(POWER_FEEDBACK, "505")
-    coordinator._get_load_states()
-    coordinator._get_load_states()  # second accepted sample (R2a)
+    _states, now = _warm_power(hass, coordinator, 505)
     assert coordinator._load_learned_power_w[sub_id] == 505.0
 
     coordinator._load_charging_active[sub_id] = False
-    coordinator._get_load_states()  # run 1 over
+    coordinator._get_load_states(now)  # run 1 over
 
     coordinator._load_charging_active[sub_id] = True  # run 2, lower power
-    hass.states.async_set(POWER_FEEDBACK, "400")
-    coordinator._get_load_states()
-    coordinator._get_load_states()  # second accepted sample (R2a)
+    _states, now = _warm_power(hass, coordinator, 400, start=now)
     assert coordinator._load_learned_power_w[sub_id] == 400.0  # last run wins
 
 
-async def test_first_sample_spike_is_not_learned(hass):
-    """R2a: the EMA seeds VERBATIM from a run's first accepted sample, so the
-    run-max tracker starts at the SECOND — a single start-up spike run learns
-    nothing, and a spike followed by settled samples learns the EMA-damped
-    band (a fresh settled run then replaces it entirely, last run wins)."""
+async def test_startup_spike_never_learned(hass):
+    """F-ROBUST-POWER (supersedes R2a): a run start consisting only of a
+    spike stays inside the 5-min warm-up and learns NOTHING; a spike
+    followed by settled samples learns exactly the settled level (the
+    median never blends the spike in — the old EMA landed at 781.5)."""
+    from homeassistant.util import dt as dt_util
+
     calls: list[tuple[str, str]] = []
     coordinator, sub_id, _data = await _setup(hass, calls)
 
-    # A run consisting of ONE spiked sample learns nothing at all.
+    # A short spike-only run (2 min < warm-up) learns nothing at all.
     coordinator._load_charging_active[sub_id] = True
-    hass.states.async_set(POWER_FEEDBACK, "900")
-    coordinator._get_load_states()
+    t0 = dt_util.utcnow()
+    _states, now = _warm_power(hass, coordinator, 900, start=t0, minutes=2.0)
+    assert sub_id not in coordinator._load_learned_power_w
     coordinator._load_charging_active[sub_id] = False
-    coordinator._get_load_states()  # run over after a single sample
+    coordinator._get_load_states(now)  # run over
     assert sub_id not in coordinator._load_learned_power_w
 
-    # Spike + settled samples: the spike seeds the EMA but is never learned
-    # verbatim; the learned run-max is the EMA-damped second sample
-    # (0.3*505 + 0.7*900 = 781.5), decaying — not 900.
+    # Spike (2 min) + settled 505 (6 min): the estimate is the settled
+    # median from the first served value on — never a spike blend.
     coordinator._load_charging_active[sub_id] = True
-    hass.states.async_set(POWER_FEEDBACK, "900")
-    coordinator._get_load_states()
-    hass.states.async_set(POWER_FEEDBACK, "505")
-    for _ in range(3):
-        coordinator._get_load_states()
-    assert coordinator._load_learned_power_w[sub_id] < 900.0
-    assert abs(coordinator._load_learned_power_w[sub_id] - 781.5) < 0.1
-    coordinator._load_charging_active[sub_id] = False
-    coordinator._get_load_states()  # run over
-
-    # The next clean settled run replaces the damped value: learned ~505.
-    coordinator._load_charging_active[sub_id] = True
-    coordinator._get_load_states()
-    coordinator._get_load_states()
+    _states, now = _warm_power(hass, coordinator, 900, start=now, minutes=2.0)
+    states, now = _warm_power(hass, coordinator, 505, start=now)
+    assert states[0].measured_power_w == 505.0
     assert coordinator._load_learned_power_w[sub_id] == 505.0
 
 
@@ -2110,6 +2447,43 @@ async def test_learned_power_persists_and_prunes_vanished_loads(hass):
     coordinator._store = Store(hass, coordinator._store.version, coordinator._store.key)
     await coordinator.async_load_persistent_state()
     assert coordinator._load_learned_power_w == {sub_id: 505.4}  # ghost pruned
+
+
+async def test_818_incident_transient_never_learned(hass):
+    """THE 2026-07-18 regression, HA-level twin: a stable 426 W run with one
+    1711 W transient held ~60 s (inverter-transfer compressor restart) must
+    keep estimate AND learned value in the 426 W band — no 818-class blend."""
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, power_w=400.0)
+    coordinator._load_charging_active[sub_id] = True
+
+    _states, now = _warm_power(hass, coordinator, 426, minutes=10.0)
+    # The transient: two 30 s cycles at 1711 W (sensor holds the spike).
+    states, now = _warm_power(hass, coordinator, 1711, start=now, minutes=1.0)
+    assert states[0].measured_power_w is not None
+    assert states[0].measured_power_w <= 470.0
+    states, now = _warm_power(hass, coordinator, 426, start=now, minutes=5.0)
+    assert states[0].measured_power_w == 426.0
+    assert 420.0 <= coordinator._load_learned_power_w[sub_id] <= 470.0
+
+
+async def test_estimate_overrun_warns_at_3x_nominal(hass, caplog):
+    """A sustained estimate above 3x nominal logs ONE change-gated warning
+    (sensor-lie observability) but is still served — deliberately no clamp
+    (levels above nominal are legitimate, e.g. raised charge rates)."""
+    calls: list[tuple[str, str]] = []
+    coordinator, sub_id, _data = await _setup(hass, calls, power_w=300.0)
+    coordinator._load_charging_active[sub_id] = True
+
+    states, _now = _warm_power(hass, coordinator, 1000)
+    assert states[0].measured_power_w == 1000.0  # served, not clamped
+    assert coordinator._load_learned_power_w[sub_id] == 1000.0
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelname == "WARNING" and "exceeds 3x" in r.message
+    ]
+    assert len(warnings) == 1  # change-gated: once per run, not per cycle
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two bundled operator-specced features (2026-07-18), causally linked: fewer artificial restarts = fewer inrush transients = fewer learning poisoning opportunities.

## F-ROBUST-POWER (`docs/F-ROBUST-POWER.md`)
Incident: a 1711 W compressor-restart transient (held ~60 s by the plug) EMA-blended to exactly 818 W and was frozen+persisted by the run-max rule for a 426 W dehumidifier — phantom consumption that squeezed the fossibot into 30-min scraps. The EMA/run-max learner is replaced by a **time-weighted median** over the run's last 30 min (`core/power_learning.py`, pure, reuses `weighted_quantile`):
- spikes/dips ignored by majority (defrost, inrush, transfer transients),
- sustained changes adopted (~15 min; **fast-adopt** after 10 internally stable minutes for operator-changed charge rates),
- **5-min warm-up** — start-up inrush can never be served or learned,
- **dominance bar** (review hardening): no single sample may carry >80 % of a window's weight — closes the GAP_CAP==WARMUP single-sample hole,
- no nominal clamp (505–701 W at 300 W nominal is legitimate); >3× nominal logs a change-gated warning,
- persistence write-through with 1 W movement threshold (no `.storage` churn). Appliances: declared energy/duration rule — documented, no code change.

## F-SEAMLESS-RUNS (`docs/F-SEAMLESS-RUNS.md`)
Operator's binding min_off model: *"mindestens die konfigurierte Zeit aus, wenn es einmal ABSICHTLICH deaktiviert wurde"* — not a pause per quantum. An expired run deadline with a freshly re-booked contiguous run now **extends seamlessly**: no OFF/ON relay cycle, no dwell stamp, extension capped at the booked run, persisted in the same cycle. min_off still arms on every deliberate stop (surplus gone, target reached, G4 floor guard, no re-booking). **Energy-limited loads extend only while G2 can supervise them right now** (control switch + SOC + power feedback *readable*, not latched — review hardening from configured→readable); everything G2-unsupervisable keeps the R7/R8 duty-cycle cap. G4 ordering verified (guard always wins). Recommendation-only loads get the same seamless re-anchor for their published `active`; energy-limited rec-only keeps the FIX-5 cycle.

## Verification
- 9 pure estimator tests (exact 818 regression: 1711 W/60 s never moves the estimate out of the 426 W band; single-sample & dominance holes pinned) + 6 new executor tests (headline: supervisable energy-limited extends; unreadable sensor never extends; G4 wins; booked-run-not-min_runtime cap).
- Full WSL HA suite green; ruff clean; **goldens bit-identical** (planner untouched); versions synced 0.14.0.
- Adversarial multi-agent review (22 agents): 17 confirmed findings — 1 high, 3 medium, 13 low — **all fixed or explicitly documented** in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)