### PR TITLE
Release v0.15.1: suppress cross-day daytime pre-drain (F-STRICT-SURPLUS R6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (dehumidifier ~8 h + Fossibot, Monday still lost 1.09 kWh). It is import-free,
   floor-safe and reduces export by ~175 Wh, but it is a marginal "early bet on
   tomorrow's forecast" a full day ahead while the plan already rides the stress
-  cutoff — which the operator rejected. R6 forbids it: a DAYTIME (in-window)
-  pass-2 bet must refill the same calendar day; only night/pre-dawn slots may
-  pre-drain for a next-day clip (F-NIGHT-RESCUE keeps its carve-out). Rare edge
-  case — goldens and the F-NIGHT-RESCUE regressions are unchanged.
+  cutoff — which the operator rejected. R6 forbids it: a DAYLIGHT (`pv_wh > 0`)
+  pass-2 bet must refill the same calendar day; only night/pre-dawn slots
+  (`pv_wh == 0`) may pre-drain for a next-day clip (F-NIGHT-RESCUE keeps its
+  carve-out). Keying on daylight rather than the strong-PV window is deliberate
+  — an adversarial review showed a strong-window test leaked the bet one slot
+  past the window edge (the afternoon taper, where the live 14:00 slot sits).
+  Rare edge case — goldens and the F-NIGHT-RESCUE regressions are unchanged.
 
 ## [0.15.0] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-07-19
+
+### Fixed
+- **Cross-day daytime pre-drain (F-STRICT-SURPLUS R6).** A live v0.15.0 plan
+  booked a single Sunday-14:00 dehumidifier run "covered by otherwise-lost
+  export (215 Wh)" — a battery pre-drain in Sunday's own PV window to absorb
+  MONDAY's clip, because Monday's absorption window was power-saturated
+  (dehumidifier ~8 h + Fossibot, Monday still lost 1.09 kWh). It is import-free,
+  floor-safe and reduces export by ~175 Wh, but it is a marginal "early bet on
+  tomorrow's forecast" a full day ahead while the plan already rides the stress
+  cutoff — which the operator rejected. R6 forbids it: a DAYTIME (in-window)
+  pass-2 bet must refill the same calendar day; only night/pre-dawn slots may
+  pre-drain for a next-day clip (F-NIGHT-RESCUE keeps its carve-out). Rare edge
+  case — goldens and the F-NIGHT-RESCUE regressions are unchanged.
+
 ## [0.15.0] - 2026-07-19
 
 ### Fixed

--- a/custom_components/battery_manager/core/optimize.py
+++ b/custom_components/battery_manager/core/optimize.py
@@ -133,6 +133,21 @@ def _ramped_stress_floors(
     return floors
 
 
+def _crossday_daytime_bet(slot_date, refill_date, in_window: bool) -> bool:
+    """R6 (F-STRICT-SURPLUS, operator 2026-07-19): is this pass-2 candidate a
+    forbidden cross-day DAYTIME pre-drain?
+
+    A daytime (in-window, strong-PV) bet whose battery only refills to soc_max
+    on a LATER calendar day is draining today — in today's own surplus window —
+    to absorb a NEXT-day clip. The operator rejected that marginal bet (the live
+    2026-07-19 Sunday-14:00-for-Monday run): a daytime load belongs in its own
+    day's surplus, not a day early. Night / pre-dawn slots (NOT in-window) keep
+    the F-NIGHT-RESCUE cross-day carve-out — pre-draining overnight immediately
+    before a clip day stays allowed — and a same-day refill is always fine.
+    """
+    return in_window and refill_date > slot_date
+
+
 def _slot_serviceable(flow, slot, inverter_floor: float) -> bool:
     """One slot's R2 planner-G4 rule (F-STRICT-SURPLUS R2). A booked slot is
     serviceable iff it is neither cutoff-touching nor grid-fed:
@@ -846,6 +861,20 @@ def allocate_loads(
                         continue
                     # Bet settlement (R3): where the trial actually refills.
                     recovery = _refill_index(traj, i, soc_full)
+                    # R6 (operator 2026-07-19): no cross-day DAYTIME pre-drain.
+                    # A daytime (in-window) bet must refill the same calendar
+                    # day it runs; only night/pre-dawn slots may pre-drain for a
+                    # next-day clip (F-NIGHT-RESCUE keeps its carve-out). Stops a
+                    # load draining the battery TODAY (in today's own surplus
+                    # window) to absorb TOMORROW's clip when today does not clip
+                    # — the marginal cross-day daytime bet the operator rejected
+                    # (Sunday 14:00 for Monday, live 2026-07-19).
+                    if _crossday_daytime_bet(
+                        slot.start.date(),
+                        inputs.slots[recovery].start.date(),
+                        in_window(i),
+                    ):
+                        continue
                     export_drop = current.total_export_wh - traj.total_export_wh
                     # F-NIGHT-RESCUE R2: the c1 need is judged at the physical
                     # AC->battery->AC round trip. A pure battery detour can only

--- a/custom_components/battery_manager/core/optimize.py
+++ b/custom_components/battery_manager/core/optimize.py
@@ -133,19 +133,24 @@ def _ramped_stress_floors(
     return floors
 
 
-def _crossday_daytime_bet(slot_date, refill_date, in_window: bool) -> bool:
+def _crossday_daytime_bet(slot_date, refill_date, is_daylight: bool) -> bool:
     """R6 (F-STRICT-SURPLUS, operator 2026-07-19): is this pass-2 candidate a
     forbidden cross-day DAYTIME pre-drain?
 
-    A daytime (in-window, strong-PV) bet whose battery only refills to soc_max
-    on a LATER calendar day is draining today — in today's own surplus window —
-    to absorb a NEXT-day clip. The operator rejected that marginal bet (the live
-    2026-07-19 Sunday-14:00-for-Monday run): a daytime load belongs in its own
-    day's surplus, not a day early. Night / pre-dawn slots (NOT in-window) keep
-    the F-NIGHT-RESCUE cross-day carve-out — pre-draining overnight immediately
-    before a clip day stays allowed — and a same-day refill is always fine.
+    A DAYLIGHT bet (the slot produces PV, `pv_wh > 0`) whose battery only
+    refills to soc_max on a LATER calendar day is draining today to absorb a
+    NEXT-day clip. The operator rejected that marginal bet (the live 2026-07-19
+    Sunday-14:00-for-Monday run): a daytime load belongs in its own day's
+    surplus, not a day early. "Daylight" keys on `pv_wh > 0`, NOT on the
+    strong-PV window — the afternoon taper below `strong_pv_cutoff_w`
+    (e.g. 15:00-17:00) is still genuine daylight, and keying on the strong
+    window let the identical bet escape one slot past the window edge (the
+    live 14:00 slot sits right there). Night / pre-dawn slots (`pv_wh == 0`)
+    keep the F-NIGHT-RESCUE cross-day carve-out — pre-draining overnight
+    immediately before a clip day stays allowed — and a same-day refill is
+    always fine, matching the energy-limited daylight rule's `pv_wh > 0` test.
     """
-    return in_window and refill_date > slot_date
+    return is_daylight and refill_date > slot_date
 
 
 def _slot_serviceable(flow, slot, inverter_floor: float) -> bool:
@@ -862,17 +867,19 @@ def allocate_loads(
                     # Bet settlement (R3): where the trial actually refills.
                     recovery = _refill_index(traj, i, soc_full)
                     # R6 (operator 2026-07-19): no cross-day DAYTIME pre-drain.
-                    # A daytime (in-window) bet must refill the same calendar
-                    # day it runs; only night/pre-dawn slots may pre-drain for a
-                    # next-day clip (F-NIGHT-RESCUE keeps its carve-out). Stops a
-                    # load draining the battery TODAY (in today's own surplus
-                    # window) to absorb TOMORROW's clip when today does not clip
-                    # — the marginal cross-day daytime bet the operator rejected
-                    # (Sunday 14:00 for Monday, live 2026-07-19).
+                    # A DAYLIGHT bet (pv_wh > 0 — any production, NOT just the
+                    # strong-PV window, else the afternoon taper leaks the bet
+                    # one slot past the window edge) must refill soc_max the same
+                    # calendar day it runs; only night/pre-dawn slots (pv_wh == 0)
+                    # may pre-drain for a next-day clip (F-NIGHT-RESCUE keeps its
+                    # carve-out). Stops a load draining the battery TODAY, in
+                    # today's own daylight, to absorb TOMORROW's clip when today
+                    # does not clip — the marginal cross-day daytime bet the
+                    # operator rejected (Sunday 14:00 for Monday, live 2026-07-19).
                     if _crossday_daytime_bet(
                         slot.start.date(),
                         inputs.slots[recovery].start.date(),
-                        in_window(i),
+                        slot.pv_wh > 0.0,
                     ):
                         continue
                     export_drop = current.total_export_wh - traj.total_export_wh

--- a/custom_components/battery_manager/manifest.json
+++ b/custom_components/battery_manager/manifest.json
@@ -18,5 +18,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/danielr0815/battery-manager-ha/issues",
   "requirements": [],
-  "version": "0.15.0"
+  "version": "0.15.1"
 }

--- a/docs/F-STRICT-SURPLUS.md
+++ b/docs/F-STRICT-SURPLUS.md
@@ -153,6 +153,24 @@ F-GATE-TOPUP final quantum), then the dehumidifier; all three are surplus-only
 (objective 1), so a genuinely surplus-poor day charges them partially, never
 from the grid.
 
+**R6 — no cross-day DAYTIME pre-drain (operator decision 2026-07-19, v0.15.1).**
+A pass-2 bet at a DAYTIME slot (`in_window(i)` — inside its day's strong-PV
+window) is rejected if its refill (`_refill_index`) lands on a LATER calendar
+day (`_crossday_daytime_bet`). A daytime load belongs in its own day's surplus,
+not a day early: the live 2026-07-19 plan booked a single Sunday-14:00 run
+"covered by otherwise-lost export (215 Wh)" — a battery pre-drain in Sunday's
+own PV window to absorb MONDAY's clip, because Monday's absorption window was
+power-saturated (dehumidifier 8 h + Fossibot, Monday still lost 1.09 kWh). It
+is import-free and floor-safe and genuinely reduces export by ~175 Wh, but it
+is the marginal "early bet on tomorrow's forecast" the operator rejected —
+running while the plan already sits at the stress cutoff (`stressed_min = 20`).
+NIGHT / pre-dawn slots (not in-window) keep the F-NIGHT-RESCUE cross-day
+carve-out (pre-draining overnight immediately before a clip day), and a
+same-day refill is always fine, so R6 removes only the day-early daytime bet.
+The behaviour is rare (it needs an extreme same-day-saturated clip) — goldens
+and the F-NIGHT-RESCUE regressions are unchanged. Price: a little more lost
+surplus on such saturated days, the operator's chosen trade-off.
+
 ## 3. What deliberately does NOT change
 
 - Pass-1 direct-surplus absorption (F-RESCUE-EXPORT regime split): runs as

--- a/docs/F-STRICT-SURPLUS.md
+++ b/docs/F-STRICT-SURPLUS.md
@@ -154,17 +154,21 @@ F-GATE-TOPUP final quantum), then the dehumidifier; all three are surplus-only
 from the grid.
 
 **R6 — no cross-day DAYTIME pre-drain (operator decision 2026-07-19, v0.15.1).**
-A pass-2 bet at a DAYTIME slot (`in_window(i)` — inside its day's strong-PV
-window) is rejected if its refill (`_refill_index`) lands on a LATER calendar
-day (`_crossday_daytime_bet`). A daytime load belongs in its own day's surplus,
-not a day early: the live 2026-07-19 plan booked a single Sunday-14:00 run
+A pass-2 bet at a DAYLIGHT slot (`pv_wh > 0` — any production; deliberately NOT
+`in_window`, the strong-PV window, because the afternoon taper below
+`strong_pv_cutoff_w` is still daylight and keying on the strong window let the
+identical bet escape one slot past the window edge — where the live 14:00 slot
+sits) is rejected if its refill (`_refill_index`) lands on a LATER calendar day
+(`_crossday_daytime_bet`; the `pv_wh > 0` test matches the energy-limited
+daylight rule). A daytime load belongs in its own day's surplus, not a day
+early: the live 2026-07-19 plan booked a single Sunday-14:00 run
 "covered by otherwise-lost export (215 Wh)" — a battery pre-drain in Sunday's
 own PV window to absorb MONDAY's clip, because Monday's absorption window was
 power-saturated (dehumidifier 8 h + Fossibot, Monday still lost 1.09 kWh). It
 is import-free and floor-safe and genuinely reduces export by ~175 Wh, but it
 is the marginal "early bet on tomorrow's forecast" the operator rejected —
 running while the plan already sits at the stress cutoff (`stressed_min = 20`).
-NIGHT / pre-dawn slots (not in-window) keep the F-NIGHT-RESCUE cross-day
+NIGHT / pre-dawn slots (`pv_wh == 0`) keep the F-NIGHT-RESCUE cross-day
 carve-out (pre-draining overnight immediately before a clip day), and a
 same-day refill is always fine, so R6 removes only the day-early daytime bet.
 The behaviour is rare (it needs an extreme same-day-saturated clip) — goldens

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "battery-manager-ha"
-version = "0.15.0"
+version = "0.15.1"
 description = "Solar-battery optimizer for Home Assistant: SOC forecast, discharge-threshold planning, surplus-load and grid-support control."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/core/test_optimize.py
+++ b/tests/core/test_optimize.py
@@ -19,6 +19,7 @@ from core.model import (
 )
 from core.optimize import (
     _committed_hours,
+    _crossday_daytime_bet,
     _degrades_min_soc,
     _quantised_hours,
     _refill_index,
@@ -2799,6 +2800,24 @@ def test_card_20260719_strict_invariants_hold_end_to_end():
         if a[2] == 1 and inputs.slots[a[0]].start.date() == monday
     ]
     assert mon_pass1, "Monday's clip must still be absorbed by pass-1 runs"  # (d)
+
+
+def test_crossday_daytime_bet_predicate():
+    """R6 (operator 2026-07-19): a DAYTIME (in-window) pass-2 bet whose refill
+    lands on a LATER calendar day is a forbidden cross-day daytime pre-drain;
+    night slots (not in-window) keep the F-NIGHT-RESCUE cross-day carve-out and
+    a same-day refill is always fine."""
+    from datetime import date
+
+    sun, mon = date(2026, 7, 19), date(2026, 7, 20)
+    # Daytime + refill next day -> forbidden (the Sunday-14:00-for-Monday case).
+    assert _crossday_daytime_bet(sun, mon, in_window=True)
+    # Daytime + same-day refill -> allowed (pre-charge before a same-day peak).
+    assert not _crossday_daytime_bet(sun, sun, in_window=True)
+    # Night/pre-dawn slot (not in-window) + next-day refill -> allowed
+    # (F-NIGHT-RESCUE night pre-drain before a clip day).
+    assert not _crossday_daytime_bet(sun, mon, in_window=False)
+    assert not _crossday_daytime_bet(sun, sun, in_window=False)
 
 
 def test_slot_serviceable_grid_fed_and_both_cutoff_endpoints():

--- a/tests/core/test_optimize.py
+++ b/tests/core/test_optimize.py
@@ -2803,21 +2803,146 @@ def test_card_20260719_strict_invariants_hold_end_to_end():
 
 
 def test_crossday_daytime_bet_predicate():
-    """R6 (operator 2026-07-19): a DAYTIME (in-window) pass-2 bet whose refill
+    """R6 (operator 2026-07-19): a DAYLIGHT (pv_wh > 0) pass-2 bet whose refill
     lands on a LATER calendar day is a forbidden cross-day daytime pre-drain;
-    night slots (not in-window) keep the F-NIGHT-RESCUE cross-day carve-out and
-    a same-day refill is always fine."""
+    night slots (pv_wh == 0) keep the F-NIGHT-RESCUE cross-day carve-out and a
+    same-day refill is always fine."""
     from datetime import date
 
     sun, mon = date(2026, 7, 19), date(2026, 7, 20)
-    # Daytime + refill next day -> forbidden (the Sunday-14:00-for-Monday case).
-    assert _crossday_daytime_bet(sun, mon, in_window=True)
-    # Daytime + same-day refill -> allowed (pre-charge before a same-day peak).
-    assert not _crossday_daytime_bet(sun, sun, in_window=True)
-    # Night/pre-dawn slot (not in-window) + next-day refill -> allowed
+    # Daylight + refill next day -> forbidden (the Sunday-14:00-for-Monday case).
+    assert _crossday_daytime_bet(sun, mon, is_daylight=True)
+    # Daylight + same-day refill -> allowed (pre-charge before a same-day peak).
+    assert not _crossday_daytime_bet(sun, sun, is_daylight=True)
+    # Night/pre-dawn slot (pv == 0) + next-day refill -> allowed
     # (F-NIGHT-RESCUE night pre-drain before a clip day).
-    assert not _crossday_daytime_bet(sun, mon, in_window=False)
-    assert not _crossday_daytime_bet(sun, sun, in_window=False)
+    assert not _crossday_daytime_bet(sun, mon, is_daylight=False)
+    assert not _crossday_daytime_bet(sun, sun, is_daylight=False)
+
+
+def test_r6_suppresses_daylight_afternoon_crossday_below_strong_cutoff():
+    """R6 keys on DAYLIGHT (pv_wh > 0), NOT the strong-PV window (re-review
+    finding: keying on `in_window` let the afternoon taper below
+    strong_pv_cutoff_w leak the cross-day bet one slot past the window edge —
+    exactly where the live 14:00 slot sits). Geometry: Sunday tops off midday
+    then tapers below the 200 W cutoff (14:00-19:00 = 180..20 W), Monday clips
+    enormously (saturated), so the latest-first walk reaches back to Sunday's
+    afternoon-taper slots. Those slots are DAYLIGHT (pv > 0) but NOT in-window;
+    R6 must still suppress them. Discriminating (mutation-tight at plan level):
+    with R6 disabled the same afternoon bets book. Night slots (pv == 0) keep
+    the F-NIGHT-RESCUE cross-day carve-out."""
+    import core.optimize as opt
+
+    deh = SurplusLoad(
+        load_id="deh",
+        name="Deh",
+        nominal_power_w=400.0,
+        battery_tolerance=0.15,
+        min_runtime_min=30,
+    )
+    cfg = SystemConfig(
+        control=replace(
+            ControlParams(),
+            predrain_pv_confidence=0.7,
+            upper_pv_reserve=1.2,
+            strong_pv_cutoff_w=200.0,
+        ),
+        loads=(deh,),
+        battery=BatteryParams(
+            capacity_wh=18000.0, soc_min_percent=5.0, soc_max_percent=95.0
+        ),
+        ac_profile=LoadProfile(300.0, 100.0, 6, 22),
+        dc_profile=LoadProfile(35.0, 0.0, 0, 0),
+    )
+    now = datetime(2026, 7, 19, 8, 0)
+    sun_pv = {
+        9: 1500,
+        10: 1900,
+        11: 2000,
+        12: 1800,
+        13: 1200,
+        14: 180,
+        15: 150,
+        16: 120,
+        17: 90,
+        18: 50,
+        19: 20,
+    }  # afternoon taper < 200 W
+    mon_pv = {
+        3: 150,
+        4: 400,
+        5: 900,
+        6: 1800,
+        7: 3000,
+        8: 4200,
+        9: 5000,
+        10: 5000,
+        11: 5000,
+        12: 5000,
+        13: 4500,
+        14: 3400,
+        15: 1800,
+        16: 800,
+        17: 300,
+    }
+    pv = {}
+    for day, shape in ((19, sun_pv), (20, mon_pv)):
+        for h, w in shape.items():
+            pv[datetime(2026, 7, day, h, 0)] = float(w)
+    inputs = build_slots(
+        cfg,
+        now,
+        78.0,
+        [sum(sun_pv.values()) / 1e3, sum(mon_pv.values()) / 1e3],
+        load_states=(SurplusLoadState(load_id="deh", learned_power_w=422.0),),
+        pv_hourly=pv,
+    )
+    sunday = datetime(2026, 7, 19).date()
+
+    def daylight_afternoon_crossday(result):
+        return [
+            inputs.slots[a[0]].start.hour
+            for lp in result.load_plans
+            for a, r in zip(lp.allocations, lp.reasons, strict=True)
+            if inputs.slots[a[0]].start.date() == sunday
+            and 14 <= inputs.slots[a[0]].start.hour <= 19
+            and inputs.slots[a[0]].pv_wh > 0.0
+            and "otherwise-lost export" in r
+        ]
+
+    def night_crossday(result):
+        return [
+            inputs.slots[a[0]].start.hour
+            for lp in result.load_plans
+            for a, r in zip(lp.allocations, lp.reasons, strict=True)
+            if inputs.slots[a[0]].start.date() == sunday
+            and inputs.slots[a[0]].pv_wh == 0.0
+            and "otherwise-lost export" in r
+        ]
+
+    # R6 ON (current code): no daylight afternoon-taper cross-day bet ...
+    result = plan(cfg, inputs)
+    assert not daylight_afternoon_crossday(result), (
+        "R6 must suppress the daylight afternoon-taper cross-day pre-drain"
+    )
+    # ... but night pre-drain (pv == 0) survives (F-NIGHT-RESCUE carve-out).
+    assert night_crossday(result), "night cross-day pre-drain must still book"
+    # The afternoon-taper slots are below the strong cutoff (NOT in-window), so
+    # only the daylight-based R6 catches them — an in_window-based R6 would not.
+    for s in inputs.slots:
+        if s.start.date() == sunday and 14 <= s.start.hour <= 19:
+            assert 0.0 < s.pv_wh < 200.0  # daylight yet sub-cutoff
+
+    # Discriminating: disable R6 -> the daylight afternoon bets reappear.
+    orig = opt._crossday_daytime_bet
+    opt._crossday_daytime_bet = lambda *a, **k: False
+    try:
+        result_off = plan(cfg, inputs)
+    finally:
+        opt._crossday_daytime_bet = orig
+    assert daylight_afternoon_crossday(result_off), (
+        "geometry must produce the daylight afternoon cross-day bet without R6"
+    )
 
 
 def test_slot_serviceable_grid_fed_and_both_cutoff_endpoints():


### PR DESCRIPTION
## F-STRICT-SURPLUS R6 — no cross-day daytime pre-drain

Follow-up to v0.15.0 from a live observation. The deployed v0.15.0 plan booked a single **Sunday-14:00 dehumidifier run** with why-string `covered by otherwise-lost export (215 Wh), latest feasible slot` — a battery pre-drain in Sunday's own PV window to absorb **Monday's** clip, because Monday's absorption window was power-saturated (dehumidifier ~8 h + Fossibot, and Monday still lost 1.09 kWh).

Diagnosis: it is **not a bug** — it is import-free (`import_trade_used = 10.3 Wh`), floor-safe, not an R5 violation (Sunday genuinely does not clip, so there is no fill to protect), and it genuinely reduces total export by ~175 Wh. But it is the marginal "early bet on tomorrow's forecast" a full calendar day ahead, while the plan already sits at the stress cutoff (`stressed_min = 20`) — the behaviour the operator's own 2026-07-05 timing principle was wary of. The operator chose to suppress it.

**R6:** a DAYTIME (in-window, strong-PV) pass-2 bet must refill `soc_max` the SAME calendar day it runs; only night / pre-dawn slots (not in-window) may pre-drain for a next-day clip — so **F-NIGHT-RESCUE night pre-drain before a clip day keeps its carve-out**, and a same-day pre-charge is always fine. The predicate `_crossday_daytime_bet` is extracted and unit-tested (mutation-verified).

The triggering geometry is extremely rare (it needs an extreme same-day-saturated clip — it could not be reproduced across a wide sweep), so R6's practical footprint is tiny: **goldens and the F-NIGHT-RESCUE regressions are byte-unchanged**. Price on such saturated days: a little more lost surplus — the operator's chosen trade-off.

Focused adversarial review (read-only). Full WSL suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review outcome

An adversarial review of the first R6 commit found a real **medium leak**: R6 keyed on `in_window` (the *strong*-PV window, pv ≥ cutoff), but the afternoon PV taper below the cutoff is still daylight — so a cross-day daytime pre-drain there escaped R6, and the live 14:00 slot sits exactly at the window edge (a routine taper would move the boundary and re-expose it). Fixed in the second commit: R6 now keys on `pv_wh > 0` (daylight), matching the energy-limited daylight rule; night slots (pv == 0) keep the F-NIGHT-RESCUE carve-out. Added a mutation-tight plan-level test (a saturated next-day clip forces the walk back to Sunday afternoon-taper slots; R6 suppresses them, night slots still book, and disabling R6 makes the afternoon bets reappear). The two low test-coverage findings are closed by that test.
